### PR TITLE
More accurately calculate USD values on the Token

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -169,6 +169,7 @@ type LatestPrice @entity {
   pricingAsset: Bytes! # address of stable asset
   poolId: Pool! # last pool which set price
   price: BigDecimal! # all the latest prices
+  priceUSD: BigDecimal!
   block: BigInt! # last block that prices were updated
 }
 
@@ -189,6 +190,7 @@ type TokenPrice @entity {
   amount: BigDecimal!
   pricingAsset: Bytes! # address of stable asset
   price: BigDecimal!
+  priceUSD: BigDecimal!
   block: BigInt!
   timestamp: Int!
 }

--- a/src/mappings/helpers/constants.ts
+++ b/src/mappings/helpers/constants.ts
@@ -3,8 +3,13 @@ import { BigDecimal, BigInt, Address, dataSource } from '@graphprotocol/graph-ts
 export let ZERO = BigInt.fromI32(0);
 export let ZERO_BD = BigDecimal.fromString('0');
 export let ONE_BD = BigDecimal.fromString('1');
-export const SWAP_IN = 0;
-export const SWAP_OUT = 1;
+
+export enum TokenBalanceEvent {
+  SWAP_IN,
+  SWAP_OUT,
+  JOIN,
+  EXIT,
+}
 
 export let ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
 

--- a/src/mappings/helpers/misc.ts
+++ b/src/mappings/helpers/misc.ts
@@ -332,7 +332,7 @@ export function updateTokenBalances(
     if (latestPrice) {
       //we try to always repeg the balanceUSD and volumeUSD based on the current asset priceUSD
       token.totalBalanceUSD = token.totalBalanceNotional.times(latestPrice.priceUSD);
-      token.totalVolumeUSD = token.totalVolumeNotional.times(latestPrice.priceUSD);
+      token.totalVolumeUSD = token.totalVolumeUSD.plus(notionalBalance.times(latestPrice.priceUSD));
     }
   }
 

--- a/src/mappings/pricing.ts
+++ b/src/mappings/pricing.ts
@@ -57,6 +57,7 @@ export function updatePoolLiquidity(poolId: string, block: BigInt, pricingAsset:
       latestPrice.price = price;
       latestPrice.block = block;
       latestPrice.poolId = poolId;
+      latestPrice.priceUSD = tokenPrice.priceUSD;
       latestPrice.save();
 
       let token = getToken(tokenAddress);

--- a/src/mappings/vault.ts
+++ b/src/mappings/vault.ts
@@ -428,6 +428,7 @@ export function handleSwapEvent(event: SwapEvent): void {
 
   // update volume and balances for the tokens
   // updates token snapshots as well
+  // we need to do this after updatePoolLiquidity as that is where the latestPrice gets updated
   updateTokenBalances(tokenInAddress, tokenAmountIn, TokenBalanceEvent.SWAP_IN, event);
   updateTokenBalances(tokenOutAddress, tokenAmountOut, TokenBalanceEvent.SWAP_OUT, event);
 }


### PR DESCRIPTION
The overall goal here is to more accurately calculate the `totalBalanceUSD` and `totalVolumeUSD` on the `Token` and `TokenSnapshot`. The current issue is that both are being calculated as a running sum, but this does not take into account the changing asset price over time, leading to USD values that are far away from expected.

![Screen Shot 2021-11-07 at 10 23 03 AM](https://user-images.githubusercontent.com/91405705/140741277-c2c8fee7-c43b-4654-848c-61b188868604.png)

An example: 
https://graph-node.beets-ftm-node.com/subgraphs/name/beethovenx-v4/graphql?query=%7B%0A%20%20token(id%3A%20%220xc5e2b037d30a390e62180970b3aa4e91868764cd%22)%20%7B%0A%20%20%20%20id%0A%20%20%20%20symbol%0A%20%20%20%20totalBalanceNotional%0A%20%20%20%20totalBalanceUSD%0A%20%20%7D%0A%7D%0A

The `totalBalanceNotional` there is correct, but the `totalBalanceUSD` is off by quite a lot. It should be approx $320k instead of the $1.2 million it shows.

The proposed solution is to repeg the value using the latest asset price on each `JOIN`, `EXIT`, `SWAP_IN` and `SWAP_OUT`. The primary changes here are:

- Store the `priceUSD` on the `TokenPrice` and `LatestPrice` to allow for easier calculations. We also utilize this in the analytics tool we're building (https://info.beets.fi).
- Expand `updateTokenBalances` to additionally support `JOIN` and `EXIT` so that all logic can live in a single place.
- Always recalculate the `totalBalanceUSD` and `totalVolumeUSD` using the notional value and the latest price in USD.
- Added a small helper function `loadRequiredPoolToken` to replace the repetitive pattern

![Screen Shot 2021-11-08 at 1 37 31 PM](https://user-images.githubusercontent.com/91405705/140743382-7e682045-4a4b-4017-a2fa-6566cc1450ea.png)
 
One thing to note is that `updateTokenBalances` always needs to be called after `updatePoolLiquidity`, which is not so clear. This could get refactored to be more obvious.