### PR TITLE
[WIP] Introduce `isSafeToSwapOn`

### DIFF
--- a/manifest.template.yaml
+++ b/manifest.template.yaml
@@ -745,6 +745,8 @@ templates:
           handler: handleTransfer
         - event: SwapFeePercentageChanged(uint256)
           handler: handleSwapFeePercentageChange
+        - event: PausedStateChanged(bool)
+          handler: handlePausedStateChanged
   - kind: ethereum/contract
     name: WeightedPoolV2
     network: {{network}}
@@ -772,6 +774,8 @@ templates:
           handler: handleProtocolFeePercentageCacheUpdated
         - event: RecoveryModeStateChanged(bool)
           handler: handleRecoveryModeStateChanged
+        - event: PausedStateChanged(bool)
+          handler: handlePausedStateChanged
   - kind: ethereum/contract
     name: WeightedPool2Tokens
     network: {{network}}
@@ -797,6 +801,8 @@ templates:
           handler: handleOracleEnabledChanged
         - event: SwapFeePercentageChanged(uint256)
           handler: handleSwapFeePercentageChange
+        - event: PausedStateChanged(bool)
+          handler: handlePausedStateChanged
   - kind: ethereum/contract
     name: StablePool
     network: {{network}}
@@ -824,6 +830,8 @@ templates:
           handler: handleAmpUpdateStarted
         - event: AmpUpdateStopped(uint256)
           handler: handleAmpUpdateStopped
+        - event: PausedStateChanged(bool)
+          handler: handlePausedStateChanged
   - kind: ethereum/contract
     name: MetaStablePool
     network: {{network}}
@@ -860,6 +868,8 @@ templates:
           handler: handlePriceRateCacheUpdated
         - event: OracleEnabledChanged(bool)
           handler: handleOracleEnabledChanged
+        - event: PausedStateChanged(bool)
+          handler: handlePausedStateChanged
   - kind: ethereum/contract
     name: ConvergentCurvePool
     network: {{network}}
@@ -909,6 +919,8 @@ templates:
           handler: handleSwapEnabledSet
         - event: GradualWeightUpdateScheduled(uint256,uint256,uint256[],uint256[])
           handler: handleGradualWeightUpdateScheduled
+        - event: PausedStateChanged(bool)
+          handler: handlePausedStateChanged
   - kind: ethereum/contract
     name: InvestmentPool
     network: {{network}}
@@ -975,6 +987,8 @@ templates:
           handler: handlePriceRateProviderSet
         - event: TokenRateCacheUpdated(indexed address,uint256)
           handler: handlePriceRateCacheUpdated
+        - event: PausedStateChanged(bool)
+          handler: handlePausedStateChanged
   - kind: ethereum/contract
     name: StablePhantomPoolV2
     network: {{network}}
@@ -1013,6 +1027,8 @@ templates:
           handler: handleProtocolFeePercentageCacheUpdated
         - event: RecoveryModeStateChanged(bool)
           handler: handleRecoveryModeStateChanged
+        - event: PausedStateChanged(bool)
+          handler: handlePausedStateChanged
   - kind: ethereum/contract
     name: LinearPool
     network: {{network}}
@@ -1039,6 +1055,8 @@ templates:
           handler: handleSwapFeePercentageChange
         - event: TargetsSet(indexed address,uint256,uint256)
           handler: handleTargetsSet
+        - event: PausedStateChanged(bool)
+          handler: handlePausedStateChanged
   - kind: ethereum/contract
     name: Gyro2Pool
     network: {{network}}

--- a/schema.graphql
+++ b/schema.graphql
@@ -139,6 +139,7 @@ type PriceRateProvider @entity {
   poolId: Pool!
   token: PoolToken!
   address: Bytes!
+  isVerified: Boolean # TODO: make non-nullable on next full sync
   rate: BigDecimal
   lastCached: Int
   cacheDuration: Int

--- a/schema.graphql
+++ b/schema.graphql
@@ -21,6 +21,7 @@ type Pool @entity {
   symbol: String
   name: String
   swapEnabled: Boolean!
+  isSafeToSwapOn: Boolean!
   swapFee: BigDecimal!
   owner: Bytes
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -23,7 +23,8 @@ type Pool @entity {
   isPaused: Boolean
   " The pool's internal swapEnabled property. Applies to Investment Pools and LBPs. "
   swapEnabled_: Boolean!
-  isSafeToSwapOn: Boolean!
+  " Curated attribute. Combines the pool's internal swapEnabled property with Pause, RecoveryMode (when it might be impossible to swap) and verified rate providers. "
+  swapEnabled: Boolean!
   swapFee: BigDecimal!
   owner: Bytes
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -21,7 +21,8 @@ type Pool @entity {
   symbol: String
   name: String
   isPaused: Boolean
-  swapEnabled: Boolean!
+  " The pool's internal swapEnabled property. Applies to Investment Pools and LBPs. "
+  swapEnabled_: Boolean!
   isSafeToSwapOn: Boolean!
   swapFee: BigDecimal!
   owner: Bytes

--- a/schema.graphql
+++ b/schema.graphql
@@ -20,6 +20,7 @@ type Pool @entity {
   oracleEnabled: Boolean!
   symbol: String
   name: String
+  isPaused: Boolean
   swapEnabled: Boolean!
   isSafeToSwapOn: Boolean!
   swapFee: BigDecimal!
@@ -54,6 +55,7 @@ type Pool @entity {
 
   # Linear, MetaStable, StablePhantom, Composable, WeightedV2
   priceRateProviders: [PriceRateProvider!] @derivedFrom(field: "poolId")
+  allRateProvidersVerified: Boolean
 
   # ConvergentCurvePool (Element) Only
   principalToken: Bytes
@@ -100,7 +102,7 @@ type Pool @entity {
   epsilon: BigDecimal
 
   # Composable and WeightedV2 Only
-  recoveryMode: Boolean
+  isInRecoveryMode: Boolean
   protocolSwapFeeCache: BigDecimal
   protocolYieldFeeCache: BigDecimal
   protocolAumFeeCache: BigDecimal

--- a/schema.graphql
+++ b/schema.graphql
@@ -146,6 +146,11 @@ type PriceRateProvider @entity {
   cacheExpiry: Int
 }
 
+type RateProviderContract @entity {
+  id: ID!
+  poolTokens: [PoolToken!]!
+}
+
 type PoolShare @entity {
   id: ID!
   userAddress: User!

--- a/schema.graphql
+++ b/schema.graphql
@@ -100,6 +100,7 @@ type Pool @entity {
   epsilon: BigDecimal
 
   # Composable and WeightedV2 Only
+  recoveryMode: Boolean
   protocolSwapFeeCache: BigDecimal
   protocolYieldFeeCache: BigDecimal
   protocolAumFeeCache: BigDecimal

--- a/schema.graphql
+++ b/schema.graphql
@@ -49,10 +49,10 @@ type Pool @entity {
   # LiquidityBootstrappingPool Only
   weightUpdates: [GradualWeightUpdate!] @derivedFrom(field: "poolId")
 
-  # StablePool Only
+  # All kinds of StablePools Only
   amp: BigInt
 
-  # MetaStablePool and LinearPool Only
+  # Linear, MetaStable, StablePhantom, Composable, WeightedV2
   priceRateProviders: [PriceRateProvider!] @derivedFrom(field: "poolId")
 
   # ConvergentCurvePool (Element) Only

--- a/src/mappings/helpers/pools.ts
+++ b/src/mappings/helpers/pools.ts
@@ -1,10 +1,10 @@
 import { Address, Bytes, dataSource, log } from '@graphprotocol/graph-ts';
-import { Pool, PriceRateProvider } from '../../types/schema';
+import { Pool } from '../../types/schema';
 import { Vault } from '../../types/Vault/Vault';
 import { WeightedPoolV2 } from '../../types/WeightedPoolV2Factory/WeightedPoolV2';
 import { setPriceRateProvider } from '../poolController';
 import { VAULT_ADDRESS } from './constants';
-import { bytesToAddress, getPoolTokenId } from './misc';
+import { bytesToAddress } from './misc';
 
 // eslint-disable-next-line @typescript-eslint/no-namespace
 export namespace PoolType {

--- a/src/mappings/helpers/pools.ts
+++ b/src/mappings/helpers/pools.ts
@@ -54,6 +54,18 @@ export function isStableLikePool(pool: Pool): boolean {
   );
 }
 
+export function isVerifiedRateProviderOfItself(pool: Pool): boolean {
+  return (
+    pool.poolType == PoolType.Weighted ||
+    pool.poolType == PoolType.Stable ||
+    pool.poolType == PoolType.MetaStable ||
+    pool.poolType == PoolType.StablePhantom ||
+    pool.poolType == PoolType.ComposableStable ||
+    pool.poolType == PoolType.AaveLinear ||
+    pool.poolType == PoolType.ERC4626Linear
+  );
+}
+
 export function isFXPool(pool: Pool): boolean {
   return pool.poolType == PoolType.FX;
 }

--- a/src/mappings/helpers/pools.ts
+++ b/src/mappings/helpers/pools.ts
@@ -2,6 +2,7 @@ import { Address, Bytes, dataSource, log } from '@graphprotocol/graph-ts';
 import { Pool, PriceRateProvider } from '../../types/schema';
 import { Vault } from '../../types/Vault/Vault';
 import { WeightedPoolV2 } from '../../types/WeightedPoolV2Factory/WeightedPoolV2';
+import { setPriceRateProvider } from '../poolController';
 import { VAULT_ADDRESS } from './constants';
 import { bytesToAddress, getPoolTokenId } from './misc';
 
@@ -128,11 +129,6 @@ export function setPriceRateProviders(poolId: string, poolAddress: Address, toke
 
   for (let i: i32 = 0; i < rateProviders.length; i++) {
     let tokenAddress = bytesToAddress(tokensList[i]);
-    let providerId = getPoolTokenId(poolId, tokenAddress);
-    let provider = new PriceRateProvider(providerId);
-    provider.poolId = poolId;
-    provider.token = providerId;
-    provider.address = rateProviders[i];
-    provider.save();
+    setPriceRateProvider(poolId, tokenAddress, rateProviders[i], -1, -1);
   }
 }

--- a/src/mappings/helpers/pools.ts
+++ b/src/mappings/helpers/pools.ts
@@ -1,6 +1,7 @@
 import { Address, Bytes, dataSource, log } from '@graphprotocol/graph-ts';
 import { Pool, PriceRateProvider } from '../../types/schema';
 import { Vault } from '../../types/Vault/Vault';
+import { WeightedPool } from '../../types/Vault/WeightedPool';
 import { WeightedPoolV2 } from '../../types/WeightedPoolV2Factory/WeightedPoolV2';
 import { setPriceRateProvider } from '../poolController';
 import { VAULT_ADDRESS } from './constants';
@@ -165,4 +166,11 @@ export function setSafeToSwapOn(poolId: string | null): void {
     if (pool == null) return;
     pool.isSafeToSwapOn = isSafeToSwapOn(pool);
   }
+}
+
+export function updatePoolSwapEnabled(pool: Pool): void {
+  if (pool.swapEnabled) return;
+
+  pool.swapEnabled = true;
+  pool.save();
 }

--- a/src/mappings/helpers/pools.ts
+++ b/src/mappings/helpers/pools.ts
@@ -160,7 +160,7 @@ export function isPoolTypeVersionSubjectToConvergenceBug(poolType: string | null
   return false;
 }
 
-export function isSafeToSwapOn(
+export function canProcessSwaps(
   isPaused: boolean,
   isInRecoveryMode: boolean,
   swapEnabled: boolean,

--- a/src/mappings/helpers/pools.ts
+++ b/src/mappings/helpers/pools.ts
@@ -133,9 +133,7 @@ export function setPriceRateProviders(poolId: string, poolAddress: Address, toke
   }
 }
 
-export function _isSafeToSwapOn(pool: Pool, swapEnabled: boolean): boolean {
-  if (!swapEnabled) return false;
-
+export function areAllRateProvidersVerified(pool: Pool): boolean {
   if (
     pool.poolType == PoolType.ComposableStable ||
     pool.poolType == PoolType.StablePhantom ||
@@ -149,27 +147,25 @@ export function _isSafeToSwapOn(pool: Pool, swapEnabled: boolean): boolean {
         if (!rp.isVerified) return false;
       }
     }
-  } else if ((pool.poolType = PoolType.Stable)) {
-    if (pool.poolTypeVersion == 1) return false;
   }
   return true;
 }
 
-export function isSafeToSwapOn(pool: Pool): boolean {
-  return _isSafeToSwapOn(pool, pool.swapEnabled);
+export function isPoolSubjectToConvergenceBug(pool: Pool): boolean {
+  return isPoolTypeVersionSubjectToConvergenceBug(pool.poolType, pool.poolTypeVersion);
 }
 
-export function setSafeToSwapOn(poolId: string | null): void {
-  if (poolId) {
-    let pool = Pool.load(poolId);
-    if (pool == null) return;
-    pool.isSafeToSwapOn = isSafeToSwapOn(pool);
-  }
+export function isPoolTypeVersionSubjectToConvergenceBug(poolType: string | null, poolTypeVersion: i32): boolean {
+  if (poolType == PoolType.Stable && poolTypeVersion == 1) return true;
+  return false;
 }
 
-export function updatePoolSwapEnabled(pool: Pool): void {
-  if (pool.swapEnabled) return;
-
-  pool.swapEnabled = true;
-  pool.save();
+export function isSafeToSwapOn(
+  isPaused: boolean,
+  isInRecoveryMode: boolean,
+  swapEnabled: boolean,
+  allRateProvidersVerified: boolean,
+  isSubjectToConvergenceBug: boolean
+): boolean {
+  return !isPaused && !isInRecoveryMode && swapEnabled && allRateProvidersVerified && !isSubjectToConvergenceBug;
 }

--- a/src/mappings/helpers/pools.ts
+++ b/src/mappings/helpers/pools.ts
@@ -159,8 +159,10 @@ export function isSafeToSwapOn(pool: Pool): boolean {
   return _isSafeToSwapOn(pool, pool.swapEnabled);
 }
 
-export function setSafeToSwapOn(poolId: string): void {
-  let pool = Pool.load(poolId);
-  if (pool == null) return;
-  pool.isSafeToSwapOn = isSafeToSwapOn(pool);
+export function setSafeToSwapOn(poolId: string | null): void {
+  if (poolId) {
+    let pool = Pool.load(poolId);
+    if (pool == null) return;
+    pool.isSafeToSwapOn = isSafeToSwapOn(pool);
+  }
 }

--- a/src/mappings/helpers/pools.ts
+++ b/src/mappings/helpers/pools.ts
@@ -1,7 +1,6 @@
 import { Address, Bytes, dataSource, log } from '@graphprotocol/graph-ts';
 import { Pool, PriceRateProvider } from '../../types/schema';
 import { Vault } from '../../types/Vault/Vault';
-import { WeightedPool } from '../../types/Vault/WeightedPool';
 import { WeightedPoolV2 } from '../../types/WeightedPoolV2Factory/WeightedPoolV2';
 import { setPriceRateProvider } from '../poolController';
 import { VAULT_ADDRESS } from './constants';

--- a/src/mappings/poolController.ts
+++ b/src/mappings/poolController.ts
@@ -18,7 +18,15 @@ import {
   TokenRateProviderSet,
 } from '../types/templates/StablePhantomPoolV2/ComposableStablePool';
 import { AssimilatorIncluded, ParametersSet } from '../types/templates/FXPool/FXPool';
-import { Pool, PriceRateProvider, GradualWeightUpdate, AmpUpdate, SwapFeeUpdate, PoolContract } from '../types/schema';
+import {
+  Pool,
+  PriceRateProvider,
+  GradualWeightUpdate,
+  AmpUpdate,
+  SwapFeeUpdate,
+  PoolContract,
+  RateProviderContract,
+} from '../types/schema';
 
 import {
   tokenToDecimal,
@@ -311,6 +319,24 @@ export function setPriceRateProvider(
         provider.cacheExpiry = blockTimestamp + cacheDuration;
       }
     }
+  } else {
+    // if a rate provider for this poolToken already exists, remove the poolToken from the associated RateProviderContract entity
+    let previousProviderContract = RateProviderContract.load(provider.address.toHexString());
+    if (previousProviderContract) {
+      const index = previousProviderContract.poolTokens.indexOf(poolTokenId, 0);
+      if (index > -1) {
+        previousProviderContract.poolTokens.splice(index, 1);
+      }
+    }
+  }
+
+  let providerContract = RateProviderContract.load(providerAdress.toHexString());
+  if (providerContract == null) {
+    providerContract = new RateProviderContract(providerAdress.toHexString());
+  }
+  const index = providerContract.poolTokens.indexOf(poolTokenId, 0);
+  if (index < 0) {
+    providerContract.poolTokens.push(poolTokenId);
   }
 
   provider.address = providerAdress;

--- a/src/mappings/poolController.ts
+++ b/src/mappings/poolController.ts
@@ -47,7 +47,7 @@ import { PausedLocally, UnpausedLocally } from '../types/templates/Gyro2Pool/Gyr
 import { Transfer } from '../types/Vault/ERC20';
 import {
   areAllRateProvidersVerified,
-  isSafeToSwapOn,
+  canProcessSwaps,
   isPoolSubjectToConvergenceBug,
   isVerifiedRateProviderOfItself,
 } from './helpers/pools';
@@ -94,7 +94,7 @@ export function handleSwapEnabledSet(event: SwapEnabledSet): void {
   let pool = Pool.load(poolContract.pool);
   if (pool == null) return;
   pool.swapEnabled_ = event.params.swapEnabled;
-  pool.swapEnabled = isSafeToSwapOn(
+  pool.swapEnabled = canProcessSwaps(
     pool.isPaused,
     pool.isInRecoveryMode,
     event.params.swapEnabled,
@@ -111,7 +111,7 @@ export function handlePausedStateChanged(event: PausedStateChanged): void {
   let pool = Pool.load(poolContract.pool);
   if (pool == null) return;
   pool.isPaused = event.params.paused;
-  pool.swapEnabled = isSafeToSwapOn(
+  pool.swapEnabled = canProcessSwaps(
     event.params.paused,
     pool.isInRecoveryMode,
     pool.swapEnabled_,
@@ -128,7 +128,7 @@ export function handleRecoveryModeStateChanged(event: RecoveryModeStateChanged):
   let pool = Pool.load(poolContract.pool);
   if (pool == null) return;
   pool.isInRecoveryMode = event.params.enabled;
-  pool.swapEnabled = isSafeToSwapOn(
+  pool.swapEnabled = canProcessSwaps(
     pool.isPaused,
     event.params.enabled,
     pool.swapEnabled_,
@@ -145,7 +145,7 @@ export function handlePauseGyroPool(event: PausedLocally): void {
   let pool = Pool.load(poolContract.pool);
   if (pool == null) return;
   pool.isPaused = true;
-  pool.swapEnabled = isSafeToSwapOn(
+  pool.swapEnabled = canProcessSwaps(
     true,
     pool.isInRecoveryMode,
     pool.swapEnabled_,
@@ -162,7 +162,7 @@ export function handleUnpauseGyroPool(event: UnpausedLocally): void {
   let pool = Pool.load(poolContract.pool);
   if (pool == null) return;
   pool.isPaused = false;
-  pool.swapEnabled = isSafeToSwapOn(
+  pool.swapEnabled = canProcessSwaps(
     false,
     pool.isInRecoveryMode,
     pool.swapEnabled_,
@@ -405,7 +405,7 @@ export function setPriceRateProvider(
   if (pool) {
     const allRateProvidersVerified = areAllRateProvidersVerified(pool);
     pool.allRateProvidersVerified = allRateProvidersVerified;
-    pool.swapEnabled = isSafeToSwapOn(
+    pool.swapEnabled = canProcessSwaps(
       pool.isPaused,
       pool.isInRecoveryMode,
       pool.swapEnabled_,
@@ -439,7 +439,7 @@ export function setPriceRateProviderIsVerified(
               if (pool) {
                 const allRateProvidersVerified = areAllRateProvidersVerified(pool);
                 pool.allRateProvidersVerified = allRateProvidersVerified;
-                pool.swapEnabled = isSafeToSwapOn(
+                pool.swapEnabled = canProcessSwaps(
                   pool.isPaused,
                   pool.isInRecoveryMode,
                   pool.swapEnabled_,

--- a/src/mappings/poolController.ts
+++ b/src/mappings/poolController.ts
@@ -26,6 +26,7 @@ import {
   SwapFeeUpdate,
   PoolContract,
   RateProviderContract,
+  PoolToken,
 } from '../types/schema';
 
 import {
@@ -339,6 +340,31 @@ export function setPriceRateProvider(
   }
   provider.save();
   setSafeToSwapOn(poolId);
+}
+
+export function setPriceRateProviderIsVerified(
+  providerAddress: string,
+  tokenAddress: string,
+  isVerified: boolean
+): void {
+  const provider = RateProviderContract.load(providerAddress);
+  if (provider) {
+    const poolTokens = provider.poolTokens;
+    for (let i: i32 = 0; i < poolTokens.length; i++) {
+      const poolToken = PoolToken.load(poolTokens[i]);
+      if (poolToken) {
+        if (poolToken.address == tokenAddress) {
+          let rateProviderId = poolToken.id;
+          let priceRateProvider = PriceRateProvider.load(rateProviderId);
+          if (priceRateProvider) {
+            priceRateProvider.isVerified = isVerified;
+            priceRateProvider.save();
+            setSafeToSwapOn(poolToken.poolId);
+          }
+        }
+      }
+    }
+  }
 }
 
 export function handlePriceRateCacheUpdated(event: PriceRateCacheUpdated): void {

--- a/src/mappings/poolController.ts
+++ b/src/mappings/poolController.ts
@@ -1,6 +1,10 @@
 import { Address, BigDecimal, BigInt, log } from '@graphprotocol/graph-ts';
 import { OracleEnabledChanged } from '../types/templates/WeightedPool2Tokens/WeightedPool2Tokens';
-import { SwapFeePercentageChanged } from '../types/templates/WeightedPool/WeightedPool';
+import {
+  WeightedPool,
+  PausedStateChanged,
+  SwapFeePercentageChanged,
+} from '../types/templates/WeightedPool/WeightedPool';
 import {
   GradualWeightUpdateScheduled,
   SwapEnabledSet,
@@ -81,11 +85,26 @@ export function handleOracleEnabledChanged(event: OracleEnabledChanged): void {
 /************************************
  *********** SWAP ENABLED ***********
  ************************************/
+
 export function handleSwapEnabledSet(event: SwapEnabledSet): void {
   let poolAddress = event.address;
   let poolContract = PoolContract.load(poolAddress.toHexString());
   if (poolContract == null) return;
   setSwapEnabled(poolContract.pool, event.params.swapEnabled);
+}
+
+export function handlePausedStateChanged(event: PausedStateChanged): void {
+  let poolAddress = event.address;
+
+  // TODO - refactor so pool -> poolId doesn't require call
+  let poolContract = WeightedPool.bind(poolAddress);
+  let poolIdCall = poolContract.try_getPoolId();
+  let poolId = poolIdCall.value;
+
+  let pool = Pool.load(poolId.toHexString()) as Pool;
+
+  pool.swapEnabled = event.params.paused;
+  pool.save();
 }
 
 export function handleRecoveryModeStateChanged(event: RecoveryModeStateChanged): void {

--- a/src/mappings/poolController.ts
+++ b/src/mappings/poolController.ts
@@ -93,7 +93,7 @@ export function handleSwapEnabledSet(event: SwapEnabledSet): void {
   if (poolContract == null) return;
   let pool = Pool.load(poolContract.pool);
   if (pool == null) return;
-  pool.swapEnabled = event.params.swapEnabled;
+  pool.swapEnabled_ = event.params.swapEnabled;
   pool.isSafeToSwapOn = isSafeToSwapOn(
     pool.isPaused,
     pool.isInRecoveryMode,
@@ -114,7 +114,7 @@ export function handlePausedStateChanged(event: PausedStateChanged): void {
   pool.isSafeToSwapOn = isSafeToSwapOn(
     event.params.paused,
     pool.isInRecoveryMode,
-    pool.swapEnabled,
+    pool.swapEnabled_,
     pool.allRateProvidersVerified,
     isPoolSubjectToConvergenceBug(pool)
   );
@@ -131,7 +131,7 @@ export function handleRecoveryModeStateChanged(event: RecoveryModeStateChanged):
   pool.isSafeToSwapOn = isSafeToSwapOn(
     pool.isPaused,
     event.params.enabled,
-    pool.swapEnabled,
+    pool.swapEnabled_,
     pool.allRateProvidersVerified,
     isPoolSubjectToConvergenceBug(pool)
   );
@@ -148,7 +148,7 @@ export function handlePauseGyroPool(event: PausedLocally): void {
   pool.isSafeToSwapOn = isSafeToSwapOn(
     true,
     pool.isInRecoveryMode,
-    pool.swapEnabled,
+    pool.swapEnabled_,
     pool.allRateProvidersVerified,
     isPoolSubjectToConvergenceBug(pool)
   );
@@ -165,7 +165,7 @@ export function handleUnpauseGyroPool(event: UnpausedLocally): void {
   pool.isSafeToSwapOn = isSafeToSwapOn(
     false,
     pool.isInRecoveryMode,
-    pool.swapEnabled,
+    pool.swapEnabled_,
     pool.allRateProvidersVerified,
     isPoolSubjectToConvergenceBug(pool)
   );
@@ -408,7 +408,7 @@ export function setPriceRateProvider(
     pool.isSafeToSwapOn = isSafeToSwapOn(
       pool.isPaused,
       pool.isInRecoveryMode,
-      pool.swapEnabled,
+      pool.swapEnabled_,
       allRateProvidersVerified,
       isPoolSubjectToConvergenceBug(pool)
     );
@@ -442,7 +442,7 @@ export function setPriceRateProviderIsVerified(
                 pool.isSafeToSwapOn = isSafeToSwapOn(
                   pool.isPaused,
                   pool.isInRecoveryMode,
-                  pool.swapEnabled,
+                  pool.swapEnabled_,
                   allRateProvidersVerified,
                   isPoolSubjectToConvergenceBug(pool)
                 );

--- a/src/mappings/poolController.ts
+++ b/src/mappings/poolController.ts
@@ -36,6 +36,7 @@ import {
 } from '../types/WeightedPoolV2Factory/WeightedPoolV2';
 import { PausedLocally, UnpausedLocally } from '../types/templates/Gyro2Pool/Gyro2Pool';
 import { Transfer } from '../types/Vault/ERC20';
+import { getPoolAddress, isVerifiedRateProviderOfItself } from './helpers/pools';
 
 export function handleProtocolFeePercentageCacheUpdated(event: ProtocolFeePercentageCacheUpdated): void {
   let poolAddress = event.address;
@@ -309,7 +310,15 @@ export function setPriceRateProvider(
   provider.address = providerAdress;
   provider.cacheDuration = cacheDuration;
 
-  provider.save();
+  let pool = Pool.load(poolId);
+  if (pool && isVerifiedRateProviderOfItself(pool) && tokenAddress == pool.address) {
+    provider.isVerified = true
+  }
+  else {
+    provider.isVerified = false
+  }
+
+provider.save();
 }
 
 export function handlePriceRateCacheUpdated(event: PriceRateCacheUpdated): void {

--- a/src/mappings/poolController.ts
+++ b/src/mappings/poolController.ts
@@ -94,7 +94,7 @@ export function handleSwapEnabledSet(event: SwapEnabledSet): void {
   let pool = Pool.load(poolContract.pool);
   if (pool == null) return;
   pool.swapEnabled_ = event.params.swapEnabled;
-  pool.isSafeToSwapOn = isSafeToSwapOn(
+  pool.swapEnabled = isSafeToSwapOn(
     pool.isPaused,
     pool.isInRecoveryMode,
     event.params.swapEnabled,
@@ -111,7 +111,7 @@ export function handlePausedStateChanged(event: PausedStateChanged): void {
   let pool = Pool.load(poolContract.pool);
   if (pool == null) return;
   pool.isPaused = event.params.paused;
-  pool.isSafeToSwapOn = isSafeToSwapOn(
+  pool.swapEnabled = isSafeToSwapOn(
     event.params.paused,
     pool.isInRecoveryMode,
     pool.swapEnabled_,
@@ -128,7 +128,7 @@ export function handleRecoveryModeStateChanged(event: RecoveryModeStateChanged):
   let pool = Pool.load(poolContract.pool);
   if (pool == null) return;
   pool.isInRecoveryMode = event.params.enabled;
-  pool.isSafeToSwapOn = isSafeToSwapOn(
+  pool.swapEnabled = isSafeToSwapOn(
     pool.isPaused,
     event.params.enabled,
     pool.swapEnabled_,
@@ -145,7 +145,7 @@ export function handlePauseGyroPool(event: PausedLocally): void {
   let pool = Pool.load(poolContract.pool);
   if (pool == null) return;
   pool.isPaused = true;
-  pool.isSafeToSwapOn = isSafeToSwapOn(
+  pool.swapEnabled = isSafeToSwapOn(
     true,
     pool.isInRecoveryMode,
     pool.swapEnabled_,
@@ -162,7 +162,7 @@ export function handleUnpauseGyroPool(event: UnpausedLocally): void {
   let pool = Pool.load(poolContract.pool);
   if (pool == null) return;
   pool.isPaused = false;
-  pool.isSafeToSwapOn = isSafeToSwapOn(
+  pool.swapEnabled = isSafeToSwapOn(
     false,
     pool.isInRecoveryMode,
     pool.swapEnabled_,
@@ -405,7 +405,7 @@ export function setPriceRateProvider(
   if (pool) {
     const allRateProvidersVerified = areAllRateProvidersVerified(pool);
     pool.allRateProvidersVerified = allRateProvidersVerified;
-    pool.isSafeToSwapOn = isSafeToSwapOn(
+    pool.swapEnabled = isSafeToSwapOn(
       pool.isPaused,
       pool.isInRecoveryMode,
       pool.swapEnabled_,
@@ -439,7 +439,7 @@ export function setPriceRateProviderIsVerified(
               if (pool) {
                 const allRateProvidersVerified = areAllRateProvidersVerified(pool);
                 pool.allRateProvidersVerified = allRateProvidersVerified;
-                pool.isSafeToSwapOn = isSafeToSwapOn(
+                pool.swapEnabled = isSafeToSwapOn(
                   pool.isPaused,
                   pool.isInRecoveryMode,
                   pool.swapEnabled_,

--- a/src/mappings/poolController.ts
+++ b/src/mappings/poolController.ts
@@ -44,7 +44,7 @@ import {
 } from '../types/WeightedPoolV2Factory/WeightedPoolV2';
 import { PausedLocally, UnpausedLocally } from '../types/templates/Gyro2Pool/Gyro2Pool';
 import { Transfer } from '../types/Vault/ERC20';
-import { getPoolAddress, isVerifiedRateProviderOfItself } from './helpers/pools';
+import { isVerifiedRateProviderOfItself } from './helpers/pools';
 
 export function handleProtocolFeePercentageCacheUpdated(event: ProtocolFeePercentageCacheUpdated): void {
   let poolAddress = event.address;

--- a/src/mappings/poolController.ts
+++ b/src/mappings/poolController.ts
@@ -337,9 +337,8 @@ export function setPriceRateProvider(
   } else {
     provider.isVerified = false;
   }
-  setSafeToSwapOn(poolId);
-
   provider.save();
+  setSafeToSwapOn(poolId);
 }
 
 export function handlePriceRateCacheUpdated(event: PriceRateCacheUpdated): void {

--- a/src/mappings/poolFactory.ts
+++ b/src/mappings/poolFactory.ts
@@ -450,7 +450,7 @@ function createNewPool(
     const allRateProvidersVerified = areAllRateProvidersVerified(pool);
     pool.allRateProvidersVerified = allRateProvidersVerified;
     const isPoolSubjectToConvergenceBug = isPoolTypeVersionSubjectToConvergenceBug(poolType, poolTypeVersion);
-    pool.isSafeToSwapOn = isSafeToSwapOn(
+    pool.swapEnabled = isSafeToSwapOn(
       false,
       pool.isInRecoveryMode,
       true,

--- a/src/mappings/poolFactory.ts
+++ b/src/mappings/poolFactory.ts
@@ -5,6 +5,7 @@ import {
   isMetaStableDeprecated,
   PoolType,
   setPriceRateProviders,
+  _isSafeToSwapOn,
 } from './helpers/pools';
 
 import {
@@ -444,6 +445,7 @@ function handleNewPool(event: PoolCreated, poolId: Bytes, swapFee: BigInt): Pool
     pool.oracleEnabled = false;
     pool.tx = event.transaction.hash;
     pool.swapEnabled = true;
+    pool.isSafeToSwapOn = _isSafeToSwapOn(pool, true);
 
     let bpt = ERC20.bind(poolAddress);
 

--- a/src/mappings/poolFactory.ts
+++ b/src/mappings/poolFactory.ts
@@ -4,7 +4,7 @@ import {
   getPoolTokenManager,
   getPoolTokens,
   isMetaStableDeprecated,
-  isSafeToSwapOn,
+  canProcessSwaps,
   isPoolSubjectToConvergenceBug,
   PoolType,
   setPriceRateProviders,
@@ -450,7 +450,7 @@ function createNewPool(
     const allRateProvidersVerified = areAllRateProvidersVerified(pool);
     pool.allRateProvidersVerified = allRateProvidersVerified;
     const isPoolSubjectToConvergenceBug = isPoolTypeVersionSubjectToConvergenceBug(poolType, poolTypeVersion);
-    pool.swapEnabled = isSafeToSwapOn(
+    pool.swapEnabled = canProcessSwaps(
       false,
       pool.isInRecoveryMode,
       true,

--- a/src/mappings/poolFactory.ts
+++ b/src/mappings/poolFactory.ts
@@ -443,7 +443,7 @@ function createNewPool(
     pool.factory = event.address;
     pool.oracleEnabled = false;
     pool.tx = event.transaction.hash;
-    pool.swapEnabled = true;
+    pool.swapEnabled_ = true;
     pool.isPaused = false;
     pool.poolType = poolType;
     pool.poolTypeVersion = poolTypeVersion;

--- a/src/mappings/vault.ts
+++ b/src/mappings/vault.ts
@@ -114,7 +114,7 @@ function handlePoolJoined(event: PoolBalanceChanged): void {
   }
   // If the pool was paused and a join occurs, it means the pause period has expired.
   pool.isPaused = false;
-  pool.isSafeToSwapOn = isSafeToSwapOn(
+  pool.swapEnabled = isSafeToSwapOn(
     false,
     pool.isInRecoveryMode,
     pool.swapEnabled_,
@@ -220,7 +220,7 @@ function handlePoolExited(event: PoolBalanceChanged): void {
   }
   // If the pool was paused and a join occurs, it means the pause period has expired.
   pool.isPaused = false;
-  pool.isSafeToSwapOn = isSafeToSwapOn(
+  pool.swapEnabled = isSafeToSwapOn(
     false,
     pool.isInRecoveryMode,
     pool.swapEnabled_,
@@ -361,7 +361,7 @@ export function handleSwapEvent(event: SwapEvent): void {
   }
   // If the pool was paused and a swap occurs, it means the pause period has expired.
   pool.isPaused = false;
-  pool.isSafeToSwapOn = isSafeToSwapOn(
+  pool.swapEnabled = isSafeToSwapOn(
     false,
     pool.isInRecoveryMode,
     pool.swapEnabled_,

--- a/src/mappings/vault.ts
+++ b/src/mappings/vault.ts
@@ -117,7 +117,7 @@ function handlePoolJoined(event: PoolBalanceChanged): void {
   pool.isSafeToSwapOn = isSafeToSwapOn(
     false,
     pool.isInRecoveryMode,
-    pool.swapEnabled,
+    pool.swapEnabled_,
     pool.allRateProvidersVerified,
     isPoolSubjectToConvergenceBug(pool)
   );
@@ -223,7 +223,7 @@ function handlePoolExited(event: PoolBalanceChanged): void {
   pool.isSafeToSwapOn = isSafeToSwapOn(
     false,
     pool.isInRecoveryMode,
-    pool.swapEnabled,
+    pool.swapEnabled_,
     pool.allRateProvidersVerified,
     isPoolSubjectToConvergenceBug(pool)
   );
@@ -364,7 +364,7 @@ export function handleSwapEvent(event: SwapEvent): void {
   pool.isSafeToSwapOn = isSafeToSwapOn(
     false,
     pool.isInRecoveryMode,
-    pool.swapEnabled,
+    pool.swapEnabled_,
     pool.allRateProvidersVerified,
     isPoolSubjectToConvergenceBug(pool)
   );

--- a/src/mappings/vault.ts
+++ b/src/mappings/vault.ts
@@ -48,6 +48,7 @@ import {
   isLinearPool,
   isFXPool,
   isComposableStablePool,
+  updatePoolSwapEnabled,
 } from './helpers/pools';
 import { updateAmpFactor } from './helpers/stable';
 import { BaseToUsdAssimilator } from '../types/Vault/BaseToUsdAssimilator';
@@ -110,6 +111,7 @@ function handlePoolJoined(event: PoolBalanceChanged): void {
     log.warning('Pool not found in handlePoolJoined: {} {}', [poolId, transactionHash.toHexString()]);
     return;
   }
+
   let tokenAddresses = pool.tokensList;
 
   let joinId = transactionHash.toHexString().concat(logIndex.toString());
@@ -191,6 +193,7 @@ function handlePoolJoined(event: PoolBalanceChanged): void {
     pool.save();
   }
 
+  updatePoolSwapEnabled(pool);
   updatePoolLiquidity(poolId, blockTimestamp);
 }
 
@@ -275,6 +278,7 @@ function handlePoolExited(event: PoolBalanceChanged): void {
     }
   }
 
+  updatePoolSwapEnabled(pool);
   updatePoolLiquidity(poolId, blockTimestamp);
 }
 
@@ -555,5 +559,6 @@ export function handleSwapEvent(event: SwapEvent): void {
     addHistoricalPoolLiquidityRecord(poolId.toHex(), block, preferentialToken);
   }
 
+  updatePoolSwapEnabled(pool);
   updatePoolLiquidity(poolId.toHex(), blockTimestamp);
 }

--- a/src/mappings/vault.ts
+++ b/src/mappings/vault.ts
@@ -48,7 +48,7 @@ import {
   isLinearPool,
   isFXPool,
   isComposableStablePool,
-  isSafeToSwapOn,
+  canProcessSwaps,
   isPoolSubjectToConvergenceBug,
 } from './helpers/pools';
 import { updateAmpFactor } from './helpers/stable';
@@ -114,7 +114,7 @@ function handlePoolJoined(event: PoolBalanceChanged): void {
   }
   // If the pool was paused and a join occurs, it means the pause period has expired.
   pool.isPaused = false;
-  pool.swapEnabled = isSafeToSwapOn(
+  pool.swapEnabled = canProcessSwaps(
     false,
     pool.isInRecoveryMode,
     pool.swapEnabled_,
@@ -220,7 +220,7 @@ function handlePoolExited(event: PoolBalanceChanged): void {
   }
   // If the pool was paused and a join occurs, it means the pause period has expired.
   pool.isPaused = false;
-  pool.swapEnabled = isSafeToSwapOn(
+  pool.swapEnabled = canProcessSwaps(
     false,
     pool.isInRecoveryMode,
     pool.swapEnabled_,
@@ -361,7 +361,7 @@ export function handleSwapEvent(event: SwapEvent): void {
   }
   // If the pool was paused and a swap occurs, it means the pause period has expired.
   pool.isPaused = false;
-  pool.swapEnabled = isSafeToSwapOn(
+  pool.swapEnabled = canProcessSwaps(
     false,
     pool.isInRecoveryMode,
     pool.swapEnabled_,


### PR DESCRIPTION
This introduces an attribute that can be used by clients to determine how viable of a candidate a pool is for swapping. 

The idea is to complement onchain pool state with offchain information supplied by trusted parties via calls to proxy smart contracts.

In particular, this initial implementation builds on the notion of _verified rate providers_ - a curation of rate providers to address the fact that faulty or malicious rate providers can cause swaps to revert.

In addition to that, it also considers all StablePools V1 as "unsafe" due to the convergence issue addressed in V2.

TODO:

- [ ] Properly handle recovery mode: it shouldn't affect `swapEnabled`, only `isSafeToSwapOn` - do this in conjunction with merging #322 into this PR
- [ ] Introduce curation smart contract for rate provider verification