### PR TITLE
disable polygon pruned deployment

### DIFF
--- a/.github/workflows/graph-beta.yml
+++ b/.github/workflows/graph-beta.yml
@@ -74,29 +74,29 @@ jobs:
           graph_subgraph_name: "balancer-polygon-v2-beta"
           graph_account: "balancer-labs"
           graph_config_file: "subgraph.polygon.yaml"
-  deploy-polygon-prune-beta:
-    runs-on: ubuntu-latest
-    environment: graph
-    steps:
-      - uses: actions/checkout@v2
-      - name: Install node
-        uses: actions/setup-node@v1
-        with:
-          node-version: 14
-      - name: Install
-        run: yarn --frozen-lockfile
-      - name: Assets
-        run: yarn generate-assets polygon-prune
-      - name: Codegen
-        run: yarn codegen
-      - name: Build
-        run: yarn build
-      - uses: gtaschuk/graph-deploy@v0.1.12
-        with:
-          graph_access_token: ${{secrets.GRAPH_ACCESS_TOKEN}}
-          graph_subgraph_name: "balancer-polygon-prune-v2-beta"
-          graph_account: "balancer-labs"
-          graph_config_file: "subgraph.polygon.yaml"
+  # deploy-polygon-prune-beta:
+  #   runs-on: ubuntu-latest
+  #   environment: graph
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - name: Install node
+  #       uses: actions/setup-node@v1
+  #       with:
+  #         node-version: 14
+  #     - name: Install
+  #       run: yarn --frozen-lockfile
+  #     - name: Assets
+  #       run: yarn generate-assets polygon-prune
+  #     - name: Codegen
+  #       run: yarn codegen
+  #     - name: Build
+  #       run: yarn build
+  #     - uses: gtaschuk/graph-deploy@v0.1.12
+  #       with:
+  #         graph_access_token: ${{secrets.GRAPH_ACCESS_TOKEN}}
+  #         graph_subgraph_name: "balancer-polygon-prune-v2-beta"
+  #         graph_account: "balancer-labs"
+  #         graph_config_file: "subgraph.polygon.yaml"
   deploy-arbitrum-beta:
     runs-on: ubuntu-latest
     environment: graph

--- a/.github/workflows/graph.yml
+++ b/.github/workflows/graph.yml
@@ -74,29 +74,29 @@ jobs:
           graph_subgraph_name: "balancer-polygon-v2"
           graph_account: "balancer-labs"
           graph_config_file: "subgraph.polygon.yaml"
-  deploy-polygon-pruned:
-    runs-on: ubuntu-latest
-    environment: graph
-    steps:
-      - uses: actions/checkout@v2
-      - name: Install node
-        uses: actions/setup-node@v1
-        with:
-          node-version: 14
-      - name: Install
-        run: yarn --frozen-lockfile
-      - name: Assets
-        run: yarn generate-assets polygon-prune
-      - name: Codegen
-        run: yarn codegen
-      - name: Build
-        run: yarn build
-      - uses: gtaschuk/graph-deploy@v0.1.12
-        with:
-          graph_access_token: ${{secrets.GRAPH_ACCESS_TOKEN}}
-          graph_subgraph_name: "balancer-polygon-prune-v2"
-          graph_account: "balancer-labs"
-          graph_config_file: "subgraph.polygon.yaml"
+  # deploy-polygon-pruned:
+  #   runs-on: ubuntu-latest
+  #   environment: graph
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - name: Install node
+  #       uses: actions/setup-node@v1
+  #       with:
+  #         node-version: 14
+  #     - name: Install
+  #       run: yarn --frozen-lockfile
+  #     - name: Assets
+  #       run: yarn generate-assets polygon-prune
+  #     - name: Codegen
+  #       run: yarn codegen
+  #     - name: Build
+  #       run: yarn build
+  #     - uses: gtaschuk/graph-deploy@v0.1.12
+  #       with:
+  #         graph_access_token: ${{secrets.GRAPH_ACCESS_TOKEN}}
+  #         graph_subgraph_name: "balancer-polygon-prune-v2"
+  #         graph_account: "balancer-labs"
+  #         graph_config_file: "subgraph.polygon.yaml"
   deploy-arbitrum:
     runs-on: ubuntu-latest
     environment: graph


### PR DESCRIPTION
# Description

Disable polygon pruned deployment so that we can promote beta to prod and deploy a new release to beta.

`polygon` and `polygon-pruned` will be on different versions until the new deployment is finalized, but that shouldn't be a problem since the diff between them is not that relevant.