### PR TITLE
register prices on preminted bpt swaps

### DIFF
--- a/src/mappings/vault.ts
+++ b/src/mappings/vault.ts
@@ -494,7 +494,7 @@ export function handleSwapEvent(event: SwapEvent): void {
   swap.tokenOutSym = poolTokenOut.symbol;
   swap.tokenAmountOut = tokenAmountOut;
 
-  swap.valueUSD = swapValueUSD;
+  swap.valueUSD = valueUSD;
 
   swap.caller = event.transaction.from;
   swap.userAddress = event.transaction.from.toHex();


### PR DESCRIPTION
# Description

Pools with pre-minted BPTs emit Swap events on Joins and Exits. Because we don't want it to count as trading volume, we set the `Swap.valueUsd` to zero. An oversight is that one of the conditions to register token prices is:

```js
swap.valueUsd.gt(MIN_SWAP_VALUE_USD)
```

This PR creates 2 different variables: 

1. `valueUsd` - used to estimate the value in USD of any Swap event (no matter if it's really a swap or liquidity provision) and use it in the condition to register prices;
3. `swapValueUsd` - used to update the overall volume metrics for the pool, token, and protocol - equal to `valueUsd` if the event represents a trade.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
