### PR TITLE
add zero check to oldUSDPrice

### DIFF
--- a/src/mappings/pricing.ts
+++ b/src/mappings/pricing.ts
@@ -259,7 +259,7 @@ export function updateLatestPrice(tokenPrice: TokenPrice, blockTimestamp: BigInt
   if (currentUSDPrice == ZERO_BD) return;
 
   let oldUSDPrice = token.latestUSDPrice;
-  if (!oldUSDPrice) {
+  if ((!oldUSDPrice) || (oldUSDPrice == ZERO_BD) ) {
     token.latestUSDPriceTimestamp = blockTimestamp;
     token.latestUSDPrice = currentUSDPrice;
     token.latestPrice = latestPrice.id;


### PR DESCRIPTION
# Description

Gnosis beta deployment failed at block 26860006 due to a division by zero apparently coming from this line


https://api.thegraph.com/subgraphs/id/Qmd2dPi5cqyvntK8y8hS5mK4rCF5E3c4EiShM8CP4ZpGTV/graphql?query=%7B%0A++tokens%28block%3A%7Bnumber%3A26860005%7D%0A++where%3A%7BlatestUSDPrice%3A0%7D%29%7B%0A++++id%0A++++latestUSDPrice%0A++%7D%0A%7D

https://gnosisscan.io/tx/0xff83e8e64f2fed98fdd88857ff53f09e6dbb49b42b03799eab54989f77ab5c95#eventlog


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Gnosis should sync past block 26860006

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
