### PR TITLE
calculate invariant for stable-like and weighted-like pools

### DIFF
--- a/src/mappings/helpers/pools.ts
+++ b/src/mappings/helpers/pools.ts
@@ -66,6 +66,14 @@ export function isLinearPool(pool: Pool): boolean {
   );
 }
 
+export function isWeightedLikePool(pool: Pool): boolean {
+  return (
+    pool.poolType == PoolType.Weighted ||
+    pool.poolType == PoolType.Investment ||
+    pool.poolType == PoolType.LiquidityBootstrapping
+  );
+}
+
 export function isStableLikePool(pool: Pool): boolean {
   return (
     pool.poolType == PoolType.Stable ||

--- a/src/mappings/helpers/stable.ts
+++ b/src/mappings/helpers/stable.ts
@@ -25,7 +25,7 @@ export function getAmp(poolContract: StablePool): BigInt {
   return amp;
 }
 
-export function calculateInvariant(amp: BigInt, balances: BigInt[], swapId: string): BigInt {
+export function calculateInvariant(amp: BigInt, balances: BigInt[], txnId: string): BigInt {
   let numTokens = balances.length;
   let sum = balances.reduce((a, b) => a.plus(b), ZERO);
 
@@ -70,7 +70,7 @@ export function calculateInvariant(amp: BigInt, balances: BigInt[], swapId: stri
     }
   }
 
-  log.error("Invariant didn't converge: {}", [swapId]);
+  log.error("Invariant didn't converge: {}", [txnId]);
 
   return invariant;
 }

--- a/src/mappings/helpers/weighted.ts
+++ b/src/mappings/helpers/weighted.ts
@@ -1,9 +1,9 @@
-import { Address } from '@graphprotocol/graph-ts';
+import { Address, BigInt, log } from '@graphprotocol/graph-ts';
 
 import { Pool } from '../../types/schema';
 import { WeightedPool } from '../../types/templates/WeightedPool/WeightedPool';
 
-import { ZERO_BD } from './constants';
+import { ONE, ZERO, ZERO_BD } from './constants';
 import { scaleDown, loadPoolToken } from './misc';
 
 export function updatePoolWeights(poolId: string): void {
@@ -38,4 +38,19 @@ export function updatePoolWeights(poolId: string): void {
   }
 
   pool.save();
+}
+
+export function calculateInvariant(balances: BigInt[], normalizedWeights: BigInt[], txnId: string): BigInt {
+  let numTokens = balances.length;
+
+  let invariant = ONE;
+  for (let i = 0; i < numTokens; i++) {
+    invariant = invariant.times(balances[i].pow(normalizedWeights[i]));
+  }
+
+  if (invariant.equals(ZERO)) {
+    log.error('Zero invariant: {}', [txnId]);
+  }
+
+  return invariant;
 }


### PR DESCRIPTION
# Description

Please include a summary of the change and if relevant which issue is fixed. Please also include relevant motivation and context.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas

### `dev` -> `master`
- [ ] I have [checked](https://balancer.github.io/balancer-subgraph-v2/status.html) that all beta deployments have synced
- [ ] I have [checked](https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-polygon-prune-v2-beta/graphql?query=%0A%7B%0A++balancers%28block%3A%7Bnumber%3A1%7D%29%7B%0A++++id%0A++%7D%0A%7D) that the earliest block in the polygon pruned deployment is [block, date/time](https://polygonscan.com/block/block)
  - [ ] The earliest block is more than 24 hours old
- [ ] I have checked that core metrics are the same in the beta and production deployments

### Merges to `dev`
- [ ] I have checked that the graft base is not a pruned deployment
