### PR TITLE
improve pricing assets logic

### DIFF
--- a/assets/arbitrum.json
+++ b/assets/arbitrum.json
@@ -29,6 +29,10 @@
     {
       "address": "0xa0b862F60edEf4452F25B4160F177db44DeB6Cf1", 
       "symbol": "GNO"
+    },
+    {
+      "address": "0x32dF62dc3aEd2cD6224193052Ce665DC18165841",
+      "symbol": "B-80RDNT-20WETH"
     }
   ]
 }

--- a/assets/polygon-prune.json
+++ b/assets/polygon-prune.json
@@ -39,14 +39,6 @@
       "symbol": "bb-am-USD"
     },
     {
-      "address": "0x6f7C932e7684666C9fd1d44527765433e01fF61d", 
-      "symbol": "MKR"
-    },
-    {
-      "address": "0x5FFD62D3C3eE2E81C00A7b9079FB248e7dF024A8", 
-      "symbol": "GNO"
-    },
-    {
       "address": "0xBA1BA1ba1BA1bA1bA1Ba1BA1ba1BA1bA1ba1ba1B", 
       "symbol": "Mock pricing asset to distinguish between pruned and full deployment"
     }

--- a/assets/polygon.json
+++ b/assets/polygon.json
@@ -37,14 +37,6 @@
     {
       "address": "0x48e6b98ef6329f8f0a30ebb8c7c960330d648085",
       "symbol": "bb-am-USD"
-    },
-    {
-      "address": "0x6f7C932e7684666C9fd1d44527765433e01fF61d", 
-      "symbol": "MKR"
-    },
-    {
-      "address": "0x5FFD62D3C3eE2E81C00A7b9079FB248e7dF024A8", 
-      "symbol": "GNO"
     }
   ],
   "fxAssets": [

--- a/src/mappings/pricing.ts
+++ b/src/mappings/pricing.ts
@@ -209,23 +209,31 @@ export function swapValueInUSD(
   if (isUSDStable(tokenOutAddress)) {
     // if one of the tokens is a stable, it takes precedence
     swapValueUSD = valueInUSD(tokenAmountOut, tokenOutAddress);
+    return swapValueUSD;
   } else if (isUSDStable(tokenInAddress)) {
     // if one of the tokens is a stable, it takes precedence
     swapValueUSD = valueInUSD(tokenAmountIn, tokenInAddress);
-  } else if (isPricingAsset(tokenInAddress) && !isPricingAsset(tokenOutAddress)) {
+    return swapValueUSD;
+  }
+
+  if (isPricingAsset(tokenInAddress) && !isPricingAsset(tokenOutAddress)) {
     // if only one of the tokens is a pricing asset, it takes precedence
     swapValueUSD = valueInUSD(tokenAmountIn, tokenInAddress);
-  } else if (isPricingAsset(tokenOutAddress) && !isPricingAsset(tokenInAddress)) {
+    if (swapValueUSD.gt(ZERO_BD)) return swapValueUSD;
+  }
+
+  if (isPricingAsset(tokenOutAddress) && !isPricingAsset(tokenInAddress)) {
     // if only one of the tokens is a pricing asset, it takes precedence
     swapValueUSD = valueInUSD(tokenAmountOut, tokenOutAddress);
-  } else {
-    // if none or both tokens are pricing assets, take the average of the known prices
-    let tokenInSwapValueUSD = valueInUSD(tokenAmountIn, tokenInAddress);
-    let tokenOutSwapValueUSD = valueInUSD(tokenAmountOut, tokenOutAddress);
-    let divisor =
-      tokenInSwapValueUSD.gt(ZERO_BD) && tokenOutSwapValueUSD.gt(ZERO_BD) ? BigDecimal.fromString('2') : ONE_BD;
-    swapValueUSD = tokenInSwapValueUSD.plus(tokenOutSwapValueUSD).div(divisor);
+    if (swapValueUSD.gt(ZERO_BD)) return swapValueUSD;
   }
+
+  // if none or both tokens are pricing assets, take the average of the known prices
+  let tokenInSwapValueUSD = valueInUSD(tokenAmountIn, tokenInAddress);
+  let tokenOutSwapValueUSD = valueInUSD(tokenAmountOut, tokenOutAddress);
+  let divisor =
+    tokenInSwapValueUSD.gt(ZERO_BD) && tokenOutSwapValueUSD.gt(ZERO_BD) ? BigDecimal.fromString('2') : ONE_BD;
+  swapValueUSD = tokenInSwapValueUSD.plus(tokenOutSwapValueUSD).div(divisor);
 
   return swapValueUSD;
 }


### PR DESCRIPTION
# Description

We noticed MKR (pricing asset on Polygon) had its `latestUSDPrice` equal to zero since it doesn't have meaningful TVL against other pricing assets. Because pricing assets take precedence when calculating the swap value in USD, all trades with MKR involved returned zero.

This PR solves these issues by 1. improving the `swapValueInUSD` function to take this into account and only return `swapValue` if it's greater than zero; 2. removing GNO and MKR from Polygon's pricing assets.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas

### Merges to `dev`
- [ ] I have checked that the graft base is not a pruned deployment
