### PR TITLE
deploy base using action v1.11

### DIFF
--- a/.github/workflows/graph-studio-beta.yml
+++ b/.github/workflows/graph-studio-beta.yml
@@ -23,7 +23,7 @@ jobs:
         run: yarn codegen
       - name: Build
         run: yarn build
-      - uses: gtaschuk/graph-deploy@v0.1.12
+      - uses: gtaschuk/graph-deploy@v0.1.11
         with:
           graph_deploy_key: ${{secrets.GRAPH_DEPLOY_KEY}}
           graph_version_label: ${GITHUB_SHA::8}

--- a/.github/workflows/graph-studio.yml
+++ b/.github/workflows/graph-studio.yml
@@ -47,7 +47,7 @@ jobs:
         run: yarn codegen
       - name: Build
         run: yarn build
-      - uses: gtaschuk/graph-deploy@v0.1.12
+      - uses: gtaschuk/graph-deploy@v0.1.11
         with:
           graph_deploy_key: ${{secrets.GRAPH_DEPLOY_KEY}}
           graph_version_label: ${GITHUB_SHA::8}


### PR DESCRIPTION
v1.12 locks graph-cli at 0.28.0 - IIUC we need the latest to deploy base subgraphs