### PR TITLE
Composablev4 handlers

### DIFF
--- a/manifest.template.yaml
+++ b/manifest.template.yaml
@@ -582,6 +582,39 @@ dataSources:
         - event: PoolCreated(indexed address)
           handler: handleNewComposableStablePoolV3
   {{/if}}
+  {{#if ComposableStablePoolV4Factory}}
+  - kind: ethereum/contract
+    name: ComposableStablePoolV4Factory
+    network: {{network}}
+    source:
+      address: '{{ComposableStablePoolV4Factory.address}}'
+      abi: ComposableStablePoolV2Factory
+      startBlock: {{ComposableStablePoolV4Factory.startBlock}}
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.5
+      language: wasm/assemblyscript
+      file: ./src/mappings/poolFactory.ts
+      entities:
+        - Balancer
+        - Pool
+      abis:
+        - name: Vault
+          file: ./abis/Vault.json
+        - name: ERC20
+          file: ./abis/ERC20.json
+        - name: WeightedPool
+          file: ./abis/WeightedPool.json
+        - name: ComposableStablePoolV2Factory
+          file: ./abis/ComposableStablePoolV2Factory.json
+        - name: ComposableStablePool
+          file: ./abis/ComposableStablePool.json
+        - name: StablePool
+          file: ./abis/StablePool.json
+      eventHandlers:
+        - event: PoolCreated(indexed address)
+          handler: handleNewComposableStablePoolV4
+  {{/if}}
   {{#if HighAmpComposableStablePoolFactory}}
   - kind: ethereum/contract
     name: HighAmpComposableStablePoolFactory

--- a/networks.yaml
+++ b/networks.yaml
@@ -1,8 +1,8 @@
 mainnet:
   network: mainnet
   graft:
-    # Block of Composable V4 factory
-    block: 16878679
+    # Mar 30
+    block: 16938731
     # always make sure the base subgraph has not been pruned
     # it should be possible to run time travel queries on it going back to the vault's startBlock
     base: QmQnxRrmWbFUTfLFeHv8qi6Tf7ZMfrUVqoK7tvbF1tapbM
@@ -191,8 +191,8 @@ goerli:
 polygon:
   network: matic
   graft:
-    # Block of Composable V4
-    block: 40613553
+    # Mar 30
+    block: 40931242
     # always make sure the base subgraph has not been pruned
     # it should be possible to run time travel queries on it going back to the vault's startBlock
     base: QmZGXcx1Vn4ZhnhSeg3MxT7sTST1y1aeD1WYcqKU61EftL
@@ -295,8 +295,8 @@ polygon:
 arbitrum:
   network: arbitrum-one
   graft:
-    # Block of Composable V4 factory
-    block: 72235860
+    # Mar 30
+    block: 75183422
     # always make sure the base subgraph has not been pruned
     # it should be possible to run time travel queries on it going back to the vault's startBlock
     base: QmWuND9LUmmeUyvWFBSGXH1NZvHYzsqKgCZU2qFsj8J9oJ

--- a/networks.yaml
+++ b/networks.yaml
@@ -2,10 +2,10 @@ mainnet:
   network: mainnet
   graft:
     # Mar 30
-    block: 16938731
+    # block: 16938731
     # always make sure the base subgraph has not been pruned
     # it should be possible to run time travel queries on it going back to the vault's startBlock
-    base: QmQnxRrmWbFUTfLFeHv8qi6Tf7ZMfrUVqoK7tvbF1tapbM
+    # base: QmQnxRrmWbFUTfLFeHv8qi6Tf7ZMfrUVqoK7tvbF1tapbM
   EventEmitter:
     address: "0x1ACfEEA57d2ac674d7E65964f155AB9348A6C290"
     startBlock: 16419620

--- a/networks.yaml
+++ b/networks.yaml
@@ -1,11 +1,11 @@
 mainnet:
   network: mainnet
   graft:
-    # Mar 15 - Block from ~00h UTC
-    # block: 16829700
+    # Block of Composable V4 factory
+    block: 16878679
     # always make sure the base subgraph has not been pruned
     # it should be possible to run time travel queries on it going back to the vault's startBlock
-    # base: QmceY3gSVLLrLcSndFt8RcTDgozD2bKtkHSKQPpHFUiAMc
+    base: QmQnxRrmWbFUTfLFeHv8qi6Tf7ZMfrUVqoK7tvbF1tapbM
   EventEmitter:
     address: "0x1ACfEEA57d2ac674d7E65964f155AB9348A6C290"
     startBlock: 16419620
@@ -191,11 +191,11 @@ goerli:
 polygon:
   network: matic
   graft:
-    # Mar 21 - Block from ~8 pm UTC
-    block: 40611103
+    # Block of Composable V4
+    block: 40613553
     # always make sure the base subgraph has not been pruned
     # it should be possible to run time travel queries on it going back to the vault's startBlock
-    base: QmW2Q8vLCbVFJUjofrCJje9xeV8cRVmaqpLvuY1gFbKWTU
+    base: QmZGXcx1Vn4ZhnhSeg3MxT7sTST1y1aeD1WYcqKU61EftL
   EventEmitter:
     address: "0xcdcECFa416EE3022030E707dC3EA13a8997D74c8"
     startBlock: 38152461
@@ -295,11 +295,11 @@ polygon:
 arbitrum:
   network: arbitrum-one
   graft:
-    # Mar 27 - Block of Weighted V4 factory
-    block: 72222060
+    # Block of Composable V4 factory
+    block: 72235860
     # always make sure the base subgraph has not been pruned
     # it should be possible to run time travel queries on it going back to the vault's startBlock
-    base: QmQrxaoANeUAqPTo3t9yHyZE5aucks8gP6wEqMrjQ8vuqA
+    base: QmWuND9LUmmeUyvWFBSGXH1NZvHYzsqKgCZU2qFsj8J9oJ
   EventEmitter:
     address: "0x8f32D631093B5418d0546f77442c5fa66187E59D"
     startBlock: 53475240


### PR DESCRIPTION
# Description

Add ComposableStablePoolV4Factory block to manifest template. Update grafting params - since no composable pools other than the test ones have been created we can use a very recent block to speed things up

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Composable V4 pools should be indexed

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas

### Merges to `dev`
- [x] I have checked that the graft base is not a pruned deployment
  - [1](https://api.thegraph.com/subgraphs/id/QmQnxRrmWbFUTfLFeHv8qi6Tf7ZMfrUVqoK7tvbF1tapbM/graphql?query=%7B%0A++balancers%28block%3A%7B%0A++++number%3A1%0A++%7D%29+%7B%0A++++id%0A++%7D%0A%7D)
  - [2](https://api.thegraph.com/subgraphs/id/QmWuND9LUmmeUyvWFBSGXH1NZvHYzsqKgCZU2qFsj8J9oJ/graphql?query=%7B%0A++balancers%28block%3A%7B%0A++++number%3A1%0A++%7D%29+%7B%0A++++id%0A++%7D%0A%7D)
  - [3](https://api.thegraph.com/subgraphs/id/QmQnxRrmWbFUTfLFeHv8qi6Tf7ZMfrUVqoK7tvbF1tapbM/graphql?query=%7B%0A++balancers%28block%3A%7B%0A++++number%3A1%0A++%7D%29+%7B%0A++++id%0A++%7D%0A%7D)
