### PR TITLE
Vaults user shares

### DIFF
--- a/src/mappings/poolFactory.ts
+++ b/src/mappings/poolFactory.ts
@@ -18,7 +18,7 @@ import {
 } from './helpers/misc';
 import { updatePoolWeights } from './helpers/weighted';
 
-import { BigInt, Address, Bytes, BigDecimal, ethereum } from '@graphprotocol/graph-ts';
+import { BigInt, Address, Bytes, ethereum } from '@graphprotocol/graph-ts';
 import { PoolCreated } from '../types/WeightedPoolFactory/WeightedPoolFactory';
 import { AaveLinearPoolCreated } from '../types/AaveLinearPoolV3Factory/AaveLinearPoolV3Factory';
 import { ProtocolIdRegistered } from '../types/ProtocolIdRegistry/ProtocolIdRegistry';
@@ -354,11 +354,11 @@ function handleNewLinearPool(event: PoolCreated, poolType: string, poolTypeVersi
   let preMintedBpt = BigInt.fromString('5192296858534827628530496329220095');
   let scaledPreMintedBpt = scaleDown(preMintedBpt, 18);
   pool.totalShares = pool.totalShares.minus(scaledPreMintedBpt);
-  // This amount will also be transferred to the vault, 
+  // This amount will also be transferred to the vault,
   // causing the vault's 'user shares' to incorrectly increase,
   // so we need to negate it. We do so by processing a mock transfer event
   // from the vault to the zero address
-  
+
   let mockEvent = new Transfer(
     bytesToAddress(pool.address),
     event.logIndex,
@@ -369,7 +369,7 @@ function handleNewLinearPool(event: PoolCreated, poolType: string, poolTypeVersi
     [
       new ethereum.EventParam('from', ethereum.Value.fromAddress(VAULT_ADDRESS)),
       new ethereum.EventParam('to', ethereum.Value.fromAddress(ZERO_ADDRESS)),
-      new ethereum.EventParam('value', ethereum.Value.fromUnsignedBigInt(preMintedBpt))
+      new ethereum.EventParam('value', ethereum.Value.fromUnsignedBigInt(preMintedBpt)),
     ],
     event.receipt
   );

--- a/src/mappings/poolFactory.ts
+++ b/src/mappings/poolFactory.ts
@@ -358,7 +358,8 @@ function handleNewLinearPool(event: PoolCreated, poolType: string, poolTypeVersi
   // causing the vault's 'user shares' to incorrectly increase,
   // so we need to negate it. We do so by processing a mock transfer event
   // from the vault to the zero address
-  const mockEvent = new Transfer(
+  
+  let mockEvent = new Transfer(
     bytesToAddress(pool.address),
     event.logIndex,
     event.transactionLogIndex,
@@ -366,10 +367,10 @@ function handleNewLinearPool(event: PoolCreated, poolType: string, poolTypeVersi
     event.block,
     event.transaction,
     [
-      VAULT_ADDRESS,
-      ZERO_ADDRESS,
-      preMintedBpt
-    ]
+      new ethereum.EventParam('from', ethereum.Value.fromAddress(VAULT_ADDRESS)),
+      new ethereum.EventParam('to', ethereum.Value.fromAddress(ZERO_ADDRESS)),
+      new ethereum.EventParam('value', ethereum.Value.fromUnsignedBigInt(preMintedBpt))
+    ],
     event.receipt
   );
   handleTransfer(mockEvent);

--- a/src/mappings/vault.ts
+++ b/src/mappings/vault.ts
@@ -1,4 +1,4 @@
-import { BigInt, BigDecimal, Address, log } from '@graphprotocol/graph-ts';
+import { BigInt, BigDecimal, Address, log, ethereum } from '@graphprotocol/graph-ts';
 import {
   Swap as SwapEvent,
   PoolBalanceChanged,
@@ -204,13 +204,15 @@ function handlePoolJoined(event: PoolBalanceChanged): void {
   // when the amount of BPT informed in the event corresponds to the "excess" BPT that was preminted
   // and therefore must be subtracted from totalShares
   if (pool.poolType == PoolType.StablePhantom || isComposableStablePool(pool)) {
-    let preMintedBpt = ZERO_BD;
+    let preMintedBpt = ZERO;
+    let scaledPreMintedBpt = ZERO_BD;
     for (let i: i32 = 0; i < tokenAddresses.length; i++) {
       if (tokenAddresses[i] == pool.address) {
-        preMintedBpt = scaleDown(amounts[i], 18);
+        preMintedBpt = amounts[i];
+        scaledPreMintedBpt = scaleDown(preMintedBpt, 18);
       }
     }
-    pool.totalShares = pool.totalShares.minus(preMintedBpt);
+    pool.totalShares = pool.totalShares.minus(scaledPreMintedBpt);
     // This amount will also be transferred to the vault, 
     // causing the vault's 'user shares' to incorrectly increase,
     // so we need to negate it. We do so by processing a mock transfer event
@@ -223,10 +225,10 @@ function handlePoolJoined(event: PoolBalanceChanged): void {
       event.block,
       event.transaction,
       [
-        VAULT_ADDRESS,
-        ZERO_ADDRESS,
-        amounts[i]
-      ]
+        new ethereum.EventParam('from', ethereum.Value.fromAddress(VAULT_ADDRESS)),
+        new ethereum.EventParam('to', ethereum.Value.fromAddress(ZERO_ADDRESS)),
+        new ethereum.EventParam('value', ethereum.Value.fromUnsignedBigInt(preMintedBpt))
+      ],
       event.receipt
     );
     handleTransfer(mockEvent);

--- a/src/mappings/vault.ts
+++ b/src/mappings/vault.ts
@@ -213,7 +213,7 @@ function handlePoolJoined(event: PoolBalanceChanged): void {
       }
     }
     pool.totalShares = pool.totalShares.minus(scaledPreMintedBpt);
-    // This amount will also be transferred to the vault, 
+    // This amount will also be transferred to the vault,
     // causing the vault's 'user shares' to incorrectly increase,
     // so we need to negate it. We do so by processing a mock transfer event
     // from the vault to the zero address
@@ -227,7 +227,7 @@ function handlePoolJoined(event: PoolBalanceChanged): void {
       [
         new ethereum.EventParam('from', ethereum.Value.fromAddress(VAULT_ADDRESS)),
         new ethereum.EventParam('to', ethereum.Value.fromAddress(ZERO_ADDRESS)),
-        new ethereum.EventParam('value', ethereum.Value.fromUnsignedBigInt(preMintedBpt))
+        new ethereum.EventParam('value', ethereum.Value.fromUnsignedBigInt(preMintedBpt)),
       ],
       event.receipt
     );


### PR DESCRIPTION
Preminted BPT is `Transfer`ed to the vault causing the vault's 'poolShare' to incorrectly increase at that point, so we need to negate it. We do so by processing a mock transfer event from the vault to the zero address on pool creation