### PR TITLE
handle RecoveryModeStateChanged in linear pools

### DIFF
--- a/abis/LinearPool.json
+++ b/abis/LinearPool.json
@@ -46,6 +46,19 @@
       "inputs": [
         {
           "indexed": false,
+          "internalType": "bool",
+          "name": "enabled",
+          "type": "bool"
+        }
+      ],
+      "name": "RecoveryModeStateChanged",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
           "internalType": "uint256",
           "name": "swapFeePercentage",
           "type": "uint256"

--- a/manifest.template.yaml
+++ b/manifest.template.yaml
@@ -1643,6 +1643,8 @@ templates:
           handler: handleSwapFeePercentageChange
         - event: TargetsSet(indexed address,uint256,uint256)
           handler: handleTargetsSet
+        - event: RecoveryModeStateChanged(bool)
+          handler: handleRecoveryModeStateChanged
         - event: PausedStateChanged(bool)
           handler: handlePausedStateChanged
   - kind: ethereum/contract


### PR DESCRIPTION
# Description

Recovery mode events were not being handled for linear pools. This extends the LinearPool ABI to introduce the event and adds the handler to the manifest.