### PR TITLE
create relationship with Token on UserInternalBalance

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -172,6 +172,7 @@ type UserInternalBalance @entity {
   id: ID!
   userAddress: User
   token: Bytes!
+  tokenInfo: Token!
   balance: BigDecimal!
 }
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -172,7 +172,7 @@ type UserInternalBalance @entity {
   id: ID!
   userAddress: User
   token: Bytes!
-  tokenInfo: Token!
+  tokenInfo: Token
   balance: BigDecimal!
 }
 

--- a/src/mappings/vault.ts
+++ b/src/mappings/vault.ts
@@ -71,19 +71,21 @@ export function handleInternalBalanceChange(event: InternalBalanceChanged): void
   createUserEntity(event.params.user);
 
   let userAddress = event.params.user.toHexString();
-  let token = event.params.token;
-  let balanceId = userAddress.concat(token.toHexString());
+  const tokenAddress = event.params.token;
+  const token = getToken(tokenAddress);
+  let balanceId = userAddress.concat(token.id);
 
   let userBalance = UserInternalBalance.load(balanceId);
   if (userBalance == null) {
     userBalance = new UserInternalBalance(balanceId);
 
     userBalance.userAddress = userAddress;
-    userBalance.token = token;
+    userBalance.tokenInfo = token.id;
+    userBalance.token = tokenAddress;
     userBalance.balance = ZERO_BD;
   }
 
-  let transferAmount = tokenToDecimal(event.params.delta, getTokenDecimals(token));
+  let transferAmount = tokenToDecimal(event.params.delta, getTokenDecimals(tokenAddress));
   userBalance.balance = userBalance.balance.plus(transferAmount);
 
   userBalance.save();


### PR DESCRIPTION
# Description

Currently, the `token` attribute from the `UserInternalBalance ` entity is the token address itself instead of a relationship with the `Token` entity. This PR fixes this by adding the `tokeInfo: Token` attribute - made it an optional field since we're grafting some chains.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas

### Merges to `dev`
- [x] I have checked that the graft base is not a pruned deployment
