### PR TITLE
add protocol fees paid

### DIFF
--- a/manifest.template.yaml
+++ b/manifest.template.yaml
@@ -1503,6 +1503,8 @@ templates:
       abis:
         - name: WeightedPool
           file: ./abis/WeightedPool.json
+        - name: Vault
+          file: ./abis/Vault.json
       eventHandlers:
         - event: Transfer(indexed address,indexed address,uint256)
           handler: handleTransfer
@@ -1528,6 +1530,8 @@ templates:
       abis:
         - name: WeightedPoolV2
           file: ./abis/WeightedPoolV2.json
+        - name: Vault
+          file: ./abis/Vault.json
       eventHandlers:
         - event: Transfer(indexed address,indexed address,uint256)
           handler: handleTransfer
@@ -1557,6 +1561,8 @@ templates:
       abis:
         - name: WeightedPool2Tokens
           file: ./abis/WeightedPool2Tokens.json
+        - name: Vault
+          file: ./abis/Vault.json
       eventHandlers:
         - event: Transfer(indexed address,indexed address,uint256)
           handler: handleTransfer
@@ -1584,6 +1590,8 @@ templates:
       abis:
         - name: StablePool
           file: ./abis/StablePool.json
+        - name: Vault
+          file: ./abis/Vault.json
       eventHandlers:
         - event: Transfer(indexed address,indexed address,uint256)
           handler: handleTransfer
@@ -1616,6 +1624,8 @@ templates:
           file: ./abis/MetaStablePool.json
         - name: StablePool
           file: ./abis/StablePool.json
+        - name: Vault
+          file: ./abis/Vault.json
       eventHandlers:
         - event: Transfer(indexed address,indexed address,uint256)
           handler: handleTransfer
@@ -1651,6 +1661,8 @@ templates:
       abis:
         - name: ConvergentCurvePool
           file: ./abis/ConvergentCurvePool.json
+        - name: Vault
+          file: ./abis/Vault.json
       eventHandlers:
         - event: Transfer(indexed address,indexed address,uint256)
           handler: handleTransfer
@@ -1673,6 +1685,8 @@ templates:
       abis:
         - name: LiquidityBootstrappingPool
           file: ./abis/LiquidityBootstrappingPool.json
+        - name: Vault
+          file: ./abis/Vault.json
       eventHandlers:
         - event: Transfer(indexed address,indexed address,uint256)
           handler: handleTransfer
@@ -1703,6 +1717,8 @@ templates:
       abis:
         - name: InvestmentPool
           file: ./abis/InvestmentPool.json
+        - name: Vault
+          file: ./abis/Vault.json
       eventHandlers:
         - event: Transfer(indexed address,indexed address,uint256)
           handler: handleTransfer
@@ -1737,6 +1753,8 @@ templates:
           file: ./abis/StablePhantomPool.json
         - name: StablePool
           file: ./abis/StablePool.json
+        - name: Vault
+          file: ./abis/Vault.json
       eventHandlers:
         - event: Transfer(indexed address,indexed address,uint256)
           handler: handleTransfer
@@ -1773,6 +1791,8 @@ templates:
           file: ./abis/ComposableStablePool.json
         - name: StablePool
           file: ./abis/StablePool.json
+        - name: Vault
+          file: ./abis/Vault.json
       eventHandlers:
         - event: Transfer(indexed address,indexed address,uint256)
           handler: handleTransfer
@@ -1811,6 +1831,8 @@ templates:
       abis:
         - name: LinearPool
           file: ./abis/LinearPool.json
+        - name: Vault
+          file: ./abis/Vault.json
       eventHandlers:
         - event: Transfer(indexed address,indexed address,uint256)
           handler: handleTransfer
@@ -1841,6 +1863,8 @@ templates:
       abis:
         - name: Gyro2Pool
           file: ./abis/Gyro2Pool.json
+        - name: Vault
+          file: ./abis/Vault.json
       eventHandlers:
         - event: Transfer(indexed address,indexed address,uint256)
           handler: handleTransfer
@@ -1869,6 +1893,8 @@ templates:
       abis:
         - name: Gyro3Pool
           file: ./abis/Gyro3Pool.json
+        - name: Vault
+          file: ./abis/Vault.json
       eventHandlers:
         - event: Transfer(indexed address,indexed address,uint256)
           handler: handleTransfer
@@ -1897,6 +1923,8 @@ templates:
       abis:
         - name: GyroEPool
           file: ./abis/GyroEPool.json
+        - name: Vault
+          file: ./abis/Vault.json
       eventHandlers:
         - event: Transfer(indexed address,indexed address,uint256)
           handler: handleTransfer
@@ -1925,6 +1953,8 @@ templates:
       abis:
         - name: FXPool
           file: ./abis/FXPool.json
+        - name: Vault
+          file: ./abis/Vault.json
       eventHandlers:
         - event: Transfer(indexed address,indexed address,uint256)
           handler: handleTransfer

--- a/schema.graphql
+++ b/schema.graphql
@@ -131,6 +131,7 @@ type PoolToken @entity {
   oldPriceRate: BigDecimal # TODO: make mandatory at next full sync
   priceRate: BigDecimal!
   balance: BigDecimal!
+  paidProtocolFees: BigDecimal!
   cashBalance: BigDecimal!
   managedBalance: BigDecimal!
   managements: [ManagementOperation!] @derivedFrom(field: "poolTokenId")

--- a/schema.graphql
+++ b/schema.graphql
@@ -138,7 +138,7 @@ type PoolToken @entity {
   oldPriceRate: BigDecimal # TODO: make mandatory at next full sync
   priceRate: BigDecimal!
   balance: BigDecimal!
-  paidProtocolFees: BigDecimal!
+  paidProtocolFees: BigDecimal # TODO: make mandatory at next full sync
   cashBalance: BigDecimal!
   managedBalance: BigDecimal!
   managements: [ManagementOperation!] @derivedFrom(field: "poolTokenId")

--- a/schema.graphql
+++ b/schema.graphql
@@ -8,6 +8,13 @@ type Balancer @entity {
   totalSwapCount: BigInt!
   totalSwapVolume: BigDecimal!
   totalSwapFee: BigDecimal!
+
+  protocolFeesCollector: ProtocolFeesCollector
+}
+
+type ProtocolFeesCollector @entity {
+  id: ID!
+  address: Bytes!
 }
 
 type Pool @entity {

--- a/schema.graphql
+++ b/schema.graphql
@@ -9,12 +9,7 @@ type Balancer @entity {
   totalSwapVolume: BigDecimal!
   totalSwapFee: BigDecimal!
 
-  protocolFeesCollector: ProtocolFeesCollector
-}
-
-type ProtocolFeesCollector @entity {
-  id: ID!
-  address: Bytes!
+  protocolFeesCollector: Bytes # TODO: make mandatory at next full sync
 }
 
 type Pool @entity {

--- a/src/mappings/helpers/misc.ts
+++ b/src/mappings/helpers/misc.ts
@@ -158,6 +158,7 @@ export function createPoolTokenEntity(
   poolToken.symbol = symbol;
   poolToken.decimals = decimals;
   poolToken.balance = ZERO_BD;
+  poolToken.paidProtocolFees = ZERO_BD;
   poolToken.cashBalance = ZERO_BD;
   poolToken.managedBalance = ZERO_BD;
   poolToken.priceRate = ONE_BD;

--- a/src/mappings/helpers/misc.ts
+++ b/src/mappings/helpers/misc.ts
@@ -414,8 +414,10 @@ export function getBalancerSnapshot(vaultId: string, timestamp: i32): BalancerSn
   return snapshot;
 }
 
-export function getProtocolFeeCollector(): Address {
+export function getProtocolFeeCollector(): Address | null {
   let vaultContract = Vault.bind(VAULT_ADDRESS);
-  let feesCollector = vaultContract.getProtocolFeesCollector();
-  return feesCollector;
+  let feesCollector = vaultContract.try_getProtocolFeesCollector();
+  if (feesCollector.reverted) return null;
+
+  return feesCollector.value;
 }

--- a/src/mappings/helpers/misc.ts
+++ b/src/mappings/helpers/misc.ts
@@ -15,8 +15,8 @@ import {
 } from '../../types/schema';
 import { ERC20 } from '../../types/Vault/ERC20';
 import { WeightedPool } from '../../types/Vault/WeightedPool';
-import { Swap as SwapEvent } from '../../types/Vault/Vault';
-import { ONE_BD, SWAP_IN, SWAP_OUT, ZERO, ZERO_BD } from './constants';
+import { Swap as SwapEvent, Vault } from '../../types/Vault/Vault';
+import { ONE_BD, SWAP_IN, SWAP_OUT, VAULT_ADDRESS, ZERO, ZERO_BD } from './constants';
 import { getPoolAddress, isComposableStablePool } from './pools';
 import { ComposableStablePool } from '../../types/ComposableStablePoolFactory/ComposableStablePool';
 import { valueInUSD } from '../pricing';
@@ -412,4 +412,10 @@ export function getBalancerSnapshot(vaultId: string, timestamp: i32): BalancerSn
   }
 
   return snapshot;
+}
+
+export function getProtocolFeeCollector(): Address {
+  let vaultContract = Vault.bind(VAULT_ADDRESS);
+  let feesCollector = vaultContract.getProtocolFeesCollector();
+  return feesCollector;
 }

--- a/src/mappings/poolController.ts
+++ b/src/mappings/poolController.ts
@@ -422,7 +422,7 @@ export function handleTransfer(event: Transfer): void {
       vault.save();
     }
 
-    if (poolShareTo.userAddress == protocolFeeCollector.toHex()) {
+    if (protocolFeeCollector && poolShareTo.userAddress == protocolFeeCollector.toHex()) {
       let poolToken = loadPoolToken(poolId, poolAddress) as PoolToken;
       let paidProtocolFees = poolToken.paidProtocolFees ? poolToken.paidProtocolFees : ZERO_BD;
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion

--- a/src/mappings/poolController.ts
+++ b/src/mappings/poolController.ts
@@ -416,7 +416,7 @@ export function handleTransfer(event: Transfer): void {
     // mint of BPT to the fee collector means the pool is paying protocol fees
     let vault = Balancer.load('2') as Balancer;
     let protocolFeeCollector = vault.protocolFeesCollector;
-    if (protocolFeeCollector == null) {
+    if (!protocolFeeCollector) {
       protocolFeeCollector = getProtocolFeeCollector();
       vault.protocolFeesCollector = protocolFeeCollector;
       vault.save();
@@ -425,7 +425,7 @@ export function handleTransfer(event: Transfer): void {
     if (poolShareTo.userAddress == protocolFeeCollector.toHex()) {
       let poolToken = loadPoolToken(poolId, poolAddress) as PoolToken;
       let paidProtocolFees = poolToken.paidProtocolFees ? poolToken.paidProtocolFees : ZERO_BD;
-      poolToken.paidProtocolFees = paidProtocolFees.plus(tokenToDecimal(event.params.value, BPT_DECIMALS));
+      poolToken.paidProtocolFees = paidProtocolFees!.plus(tokenToDecimal(event.params.value, BPT_DECIMALS));
       poolToken.save();
     }
   } else if (isBurn) {

--- a/src/mappings/poolController.ts
+++ b/src/mappings/poolController.ts
@@ -425,6 +425,7 @@ export function handleTransfer(event: Transfer): void {
     if (poolShareTo.userAddress == protocolFeeCollector.toHex()) {
       let poolToken = loadPoolToken(poolId, poolAddress) as PoolToken;
       let paidProtocolFees = poolToken.paidProtocolFees ? poolToken.paidProtocolFees : ZERO_BD;
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       poolToken.paidProtocolFees = paidProtocolFees!.plus(tokenToDecimal(event.params.value, BPT_DECIMALS));
       poolToken.save();
     }

--- a/src/mappings/poolFactory.ts
+++ b/src/mappings/poolFactory.ts
@@ -15,6 +15,7 @@ import {
   tokenToDecimal,
   stringToBytes,
   bytesToAddress,
+  getProtocolFeeCollector,
 } from './helpers/misc';
 import { updatePoolWeights } from './helpers/weighted';
 
@@ -574,15 +575,7 @@ function findOrInitializeVault(): Balancer {
   vault.totalSwapCount = ZERO;
 
   // set up protocol fees collector
-  let vaultContract = Vault.bind(VAULT_ADDRESS);
-  let feesCollectorCall = vaultContract.try_getProtocolFeesCollector();
-  if (!feesCollectorCall.reverted) {
-    let feesCollector = new ProtocolFeesCollector(feesCollectorCall.value.toHex());
-    feesCollector.address = feesCollectorCall.value;
-    feesCollector.save();
-
-    vault.protocolFeesCollector = feesCollector.id;
-  }
+  vault.protocolFeesCollector = getProtocolFeeCollector();
 
   return vault;
 }

--- a/src/mappings/poolFactory.ts
+++ b/src/mappings/poolFactory.ts
@@ -23,7 +23,7 @@ import { BigInt, Address, Bytes, ethereum } from '@graphprotocol/graph-ts';
 import { PoolCreated } from '../types/WeightedPoolFactory/WeightedPoolFactory';
 import { AaveLinearPoolCreated } from '../types/AaveLinearPoolV3Factory/AaveLinearPoolV3Factory';
 import { ProtocolIdRegistered } from '../types/ProtocolIdRegistry/ProtocolIdRegistry';
-import { Balancer, Pool, PoolContract, ProtocolFeesCollector, ProtocolIdData } from '../types/schema';
+import { Balancer, Pool, PoolContract, ProtocolIdData } from '../types/schema';
 
 // datasource
 import { OffchainAggregator, WeightedPool as WeightedPoolTemplate } from '../types/templates';
@@ -51,7 +51,6 @@ import { Gyro3Pool } from '../types/templates/Gyro3Pool/Gyro3Pool';
 import { GyroEPool } from '../types/templates/GyroEPool/GyroEPool';
 import { ERC20, Transfer } from '../types/Vault/ERC20';
 import { handleTransfer } from './poolController';
-import { Vault } from '../types/Vault/Vault';
 
 function createWeightedLikePool(event: PoolCreated, poolType: string, poolTypeVersion: i32 = 1): string | null {
   let poolAddress: Address = event.params.pool;

--- a/src/mappings/vault.ts
+++ b/src/mappings/vault.ts
@@ -203,6 +203,7 @@ function handlePoolJoined(event: PoolBalanceChanged): void {
     let amountIn = amounts[i].minus(protocolFeeAmounts[i]);
     let tokenAmountIn = tokenToDecimal(amountIn, poolToken.decimals);
     let newBalance = poolToken.balance.plus(tokenAmountIn);
+    poolToken.paidProtocolFees = poolToken.paidProtocolFees.plus(protocolFeeAmounts[i]);
     poolToken.balance = newBalance;
     poolToken.save();
 
@@ -323,6 +324,7 @@ function handlePoolExited(event: PoolBalanceChanged): void {
     let amountOut = amounts[i].minus(protocolFeeAmounts[i]).neg();
     let tokenAmountOut = tokenToDecimal(amountOut, poolToken.decimals);
     let newBalance = poolToken.balance.minus(tokenAmountOut);
+    poolToken.paidProtocolFees = poolToken.paidProtocolFees.plus(protocolFeeAmounts[i]);
     poolToken.balance = newBalance;
     poolToken.save();
 

--- a/src/mappings/vault.ts
+++ b/src/mappings/vault.ts
@@ -203,8 +203,9 @@ function handlePoolJoined(event: PoolBalanceChanged): void {
     let amountIn = amounts[i].minus(protocolFeeAmounts[i]);
     let tokenAmountIn = tokenToDecimal(amountIn, poolToken.decimals);
     let newBalance = poolToken.balance.plus(tokenAmountIn);
+    let paidProtocolFees = poolToken.paidProtocolFees ? poolToken.paidProtocolFees : ZERO_BD;
     let protocolFeeAmount = tokenToDecimal(protocolFeeAmounts[i], poolToken.decimals);
-    poolToken.paidProtocolFees = poolToken.paidProtocolFees.plus(protocolFeeAmount);
+    poolToken.paidProtocolFees = paidProtocolFees.plus(protocolFeeAmount);
     poolToken.balance = newBalance;
     poolToken.save();
 
@@ -325,8 +326,9 @@ function handlePoolExited(event: PoolBalanceChanged): void {
     let amountOut = amounts[i].minus(protocolFeeAmounts[i]).neg();
     let tokenAmountOut = tokenToDecimal(amountOut, poolToken.decimals);
     let newBalance = poolToken.balance.minus(tokenAmountOut);
+    let paidProtocolFees = poolToken.paidProtocolFees ? poolToken.paidProtocolFees : ZERO_BD;
     let protocolFeeAmount = tokenToDecimal(protocolFeeAmounts[i], poolToken.decimals);
-    poolToken.paidProtocolFees = poolToken.paidProtocolFees.plus(protocolFeeAmount);
+    poolToken.paidProtocolFees = paidProtocolFees.plus(protocolFeeAmount);
     poolToken.balance = newBalance;
     poolToken.save();
 

--- a/src/mappings/vault.ts
+++ b/src/mappings/vault.ts
@@ -205,7 +205,7 @@ function handlePoolJoined(event: PoolBalanceChanged): void {
     let newBalance = poolToken.balance.plus(tokenAmountIn);
     let paidProtocolFees = poolToken.paidProtocolFees ? poolToken.paidProtocolFees : ZERO_BD;
     let protocolFeeAmount = tokenToDecimal(protocolFeeAmounts[i], poolToken.decimals);
-    poolToken.paidProtocolFees = paidProtocolFees.plus(protocolFeeAmount);
+    poolToken.paidProtocolFees = paidProtocolFees!.plus(protocolFeeAmount);
     poolToken.balance = newBalance;
     poolToken.save();
 
@@ -328,7 +328,7 @@ function handlePoolExited(event: PoolBalanceChanged): void {
     let newBalance = poolToken.balance.minus(tokenAmountOut);
     let paidProtocolFees = poolToken.paidProtocolFees ? poolToken.paidProtocolFees : ZERO_BD;
     let protocolFeeAmount = tokenToDecimal(protocolFeeAmounts[i], poolToken.decimals);
-    poolToken.paidProtocolFees = paidProtocolFees.plus(protocolFeeAmount);
+    poolToken.paidProtocolFees = paidProtocolFees!.plus(protocolFeeAmount);
     poolToken.balance = newBalance;
     poolToken.save();
 

--- a/src/mappings/vault.ts
+++ b/src/mappings/vault.ts
@@ -205,6 +205,7 @@ function handlePoolJoined(event: PoolBalanceChanged): void {
     let newBalance = poolToken.balance.plus(tokenAmountIn);
     let paidProtocolFees = poolToken.paidProtocolFees ? poolToken.paidProtocolFees : ZERO_BD;
     let protocolFeeAmount = tokenToDecimal(protocolFeeAmounts[i], poolToken.decimals);
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     poolToken.paidProtocolFees = paidProtocolFees!.plus(protocolFeeAmount);
     poolToken.balance = newBalance;
     poolToken.save();
@@ -328,6 +329,7 @@ function handlePoolExited(event: PoolBalanceChanged): void {
     let newBalance = poolToken.balance.minus(tokenAmountOut);
     let paidProtocolFees = poolToken.paidProtocolFees ? poolToken.paidProtocolFees : ZERO_BD;
     let protocolFeeAmount = tokenToDecimal(protocolFeeAmounts[i], poolToken.decimals);
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     poolToken.paidProtocolFees = paidProtocolFees!.plus(protocolFeeAmount);
     poolToken.balance = newBalance;
     poolToken.save();

--- a/src/mappings/vault.ts
+++ b/src/mappings/vault.ts
@@ -203,7 +203,8 @@ function handlePoolJoined(event: PoolBalanceChanged): void {
     let amountIn = amounts[i].minus(protocolFeeAmounts[i]);
     let tokenAmountIn = tokenToDecimal(amountIn, poolToken.decimals);
     let newBalance = poolToken.balance.plus(tokenAmountIn);
-    poolToken.paidProtocolFees = poolToken.paidProtocolFees.plus(protocolFeeAmounts[i]);
+    let protocolFeeAmount = tokenToDecimal(protocolFeeAmounts[i], poolToken.decimals);
+    poolToken.paidProtocolFees = poolToken.paidProtocolFees.plus(protocolFeeAmount);
     poolToken.balance = newBalance;
     poolToken.save();
 
@@ -324,7 +325,8 @@ function handlePoolExited(event: PoolBalanceChanged): void {
     let amountOut = amounts[i].minus(protocolFeeAmounts[i]).neg();
     let tokenAmountOut = tokenToDecimal(amountOut, poolToken.decimals);
     let newBalance = poolToken.balance.minus(tokenAmountOut);
-    poolToken.paidProtocolFees = poolToken.paidProtocolFees.plus(protocolFeeAmounts[i]);
+    let protocolFeeAmount = tokenToDecimal(protocolFeeAmounts[i], poolToken.decimals);
+    poolToken.paidProtocolFees = poolToken.paidProtocolFees.plus(protocolFeeAmount);
     poolToken.balance = newBalance;
     poolToken.save();
 


### PR DESCRIPTION
# Description

Adds `protocolFeesPaid` to the `PoolToken` entity - this attribute is updated on: 
1. `PoolBalanceChanged` events which have the `protocolFeeAmounts[i]` telling how much fees they're paying;
2. `Transfer` events of BPTs to the fee collector - required for pools that pay fees by minting BPTs.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas