### PR TITLE
fix missing abi and protocol fee paid in bpt

### DIFF
--- a/manifest.template.yaml
+++ b/manifest.template.yaml
@@ -198,6 +198,8 @@ dataSources:
           file: ./abis/WeightedPool.json
         - name: WeightedPoolV2
           file: ./abis/WeightedPoolV2.json
+        - name: ComposableStablePool
+          file: ./abis/ComposableStablePool.json
       eventHandlers:
         - event: PoolCreated(indexed address)
           handler: handleNewWeightedPoolV4

--- a/schema.graphql
+++ b/schema.graphql
@@ -101,11 +101,12 @@ type Pool @entity {
   delta: BigDecimal
   epsilon: BigDecimal
 
-  # Composable and WeightedV2 Only
+  # Composable and WeightedV2+ Only
   isInRecoveryMode: Boolean
   protocolSwapFeeCache: BigDecimal
   protocolYieldFeeCache: BigDecimal
   protocolAumFeeCache: BigDecimal
+  totalProtocolFeePaidInBPT: BigDecimal
 
   # Composable Stable Only
   lastPostJoinExitInvariant: BigDecimal

--- a/src/mappings/poolController.ts
+++ b/src/mappings/poolController.ts
@@ -423,11 +423,9 @@ export function handleTransfer(event: Transfer): void {
     }
 
     if (protocolFeeCollector && poolShareTo.userAddress == protocolFeeCollector.toHex()) {
-      let poolToken = loadPoolToken(poolId, poolAddress) as PoolToken;
-      let paidProtocolFees = poolToken.paidProtocolFees ? poolToken.paidProtocolFees : ZERO_BD;
+      let protocolFeePaid = pool.totalProtocolFeePaidInBPT ? pool.totalProtocolFeePaidInBPT : ZERO_BD;
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      poolToken.paidProtocolFees = paidProtocolFees!.plus(tokenToDecimal(event.params.value, BPT_DECIMALS));
-      poolToken.save();
+      pool.totalProtocolFeePaidInBPT = protocolFeePaid!.plus(tokenToDecimal(event.params.value, BPT_DECIMALS));
     }
   } else if (isBurn) {
     poolShareFrom.balance = poolShareFrom.balance.minus(tokenToDecimal(event.params.value, BPT_DECIMALS));

--- a/src/mappings/poolController.ts
+++ b/src/mappings/poolController.ts
@@ -26,7 +26,6 @@ import {
   SwapFeeUpdate,
   PoolContract,
   Balancer,
-  PoolToken,
 } from '../types/schema';
 
 import {


### PR DESCRIPTION
# Description

Subgraph failed to sync on Arbitrum due to ABI missing and on Ethereum due to unexpected null. The latter happened because WeightedV2+ pays a protocol fee in BPT but doesn't pre-mint it, which means the Vault didn't register BPT as a pool's token and `PoolToken` for it doesn't exist on the Subgraph. This PR proposes moving the protocol fee paid in BPT to the `Pool` entity by adding a `totalProtocolFeePaidInBPT` attribute. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas

### Merges to `dev`
- [x] I have checked that the graft base is not a pruned deployment
