### PR TITLE
update polygon zk pricing assets

### DIFF
--- a/assets/polygon-zkevm.json
+++ b/assets/polygon-zkevm.json
@@ -23,6 +23,22 @@
       "symbol": "WETH"
     },
     {
+      "address": "0x16C9a4D841E88E52b51936106010F27085a529EC",
+      "symbol": "bb-o-USDC"
+    },
+    {
+      "address": "0x4B718E0E2fEA1dA68b763CD50C446FbA03CEB2Ea",
+      "symbol": "bb-o-USDT"
+    },
+    {
+      "address": "0xe274c9deb6ed34cfe4130F8D0A8a948deA5bB286",
+      "symbol": "bb-o-USD"
+    },
+    {
+      "address": "0xe1F2c039a68A216dE6DD427Be6c60dEcf405762A",
+      "symbol": "B-wstETH-STABLE"
+    },
+    {
       "address": "0xEA034fb02eB1808C2cc3adbC15f447B93CbE08e1",
       "symbol": "WBTC"
     },

--- a/networks.yaml
+++ b/networks.yaml
@@ -632,6 +632,9 @@ sepolia:
     startBlock: 3425305
 polygon-zkevm:
   network: polygon-zkevm
+  EventEmitter:
+    address: "0x16e29e62cC00fCBa1234C7ad89BD731427c8D9aF"
+    startBlock: 281361
   Vault:
     address: "0xBA12222222228d8Ba445958a75a0704d566BF2C8"
     startBlock: 203079


### PR DESCRIPTION
# Description

- Adds bb-o-USDC, bb-o-USDT, bb-o-USD, and b-wstETH-STABLE BPTs to Polygon zkEVM pricing assets;
- Adds `EventEmitter` to Polygon zkEVM.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas

### Merges to `dev`
- [x] I have checked that the graft base is not a pruned deployment
