### PR TITLE
add last join exit amp attribute

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -116,6 +116,7 @@ type Pool @entity {
   totalProtocolFeePaidInBPT: BigDecimal
 
   # Composable Stable Only
+  lastJoinExitAmp: BigInt
   lastPostJoinExitInvariant: BigDecimal
 
   # AaveLinearV3 Only

--- a/src/mappings/vault.ts
+++ b/src/mappings/vault.ts
@@ -578,6 +578,7 @@ export function handleSwapEvent(event: SwapEvent): void {
         let invariantInt = calculateInvariant(amp, balances, swapId);
         let invariant = scaleDown(invariantInt, 18);
         pool.lastPostJoinExitInvariant = invariant;
+        pool.lastJoinExitAmp = pool.amp;
       }
     }
   }


### PR DESCRIPTION
# Description

Adds the `lastJoinExitAmp` attribute for SDK to calculate protocol fee on CSPs.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
