### PR TITLE
fix fx oracle decimals

### DIFF
--- a/src/mappings/pricing.ts
+++ b/src/mappings/pricing.ts
@@ -353,7 +353,12 @@ export function handleAnswerUpdated(event: AnswerUpdated): void {
     return;
   }
 
-  let rate = scaleDown(event.params.current, token.fxOracleDecimals);
+  // All tokens we track have oracles with 8 decimals
+  if (token.fxOracleDecimals == null) {
+    token.fxOracleDecimals = 8;
+  }
+
+  let rate = scaleDown(event.params.current, 8);
   token.latestFXPrice = rate;
   token.save();
 }


### PR DESCRIPTION
# Description

Sync failed on Polygon due to null `fxOracleDecimals` -- this attribute is only set on Pool and Token creation (1y ago) but we're grafting based on a recent block. Since all the oracles FX tokens use (tokens are hard coded in the assets file) have 8 decimals, I'm changing the logic to set `fxOracleDecimals` on `handleAnswerUpdated` as well.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas

