### PR TITLE
fix protocol fee cache

### DIFF
--- a/manifest.template.yaml
+++ b/manifest.template.yaml
@@ -1817,6 +1817,8 @@ templates:
       abis:
         - name: WeightedPool
           file: ./abis/WeightedPool.json
+        - name: WeightedPoolV2
+          file: ./abis/WeightedPoolV2.json
         - name: ManagedPool
           file: ./abis/ManagedPoolV2.json
         - name: Vault

--- a/src/mappings/poolFactory.ts
+++ b/src/mappings/poolFactory.ts
@@ -61,6 +61,7 @@ import { Gyro3Pool } from '../types/templates/Gyro3Pool/Gyro3Pool';
 import { GyroEPool } from '../types/templates/GyroEPool/GyroEPool';
 import { Transfer } from '../types/Vault/ERC20';
 import { handleTransfer } from './poolController';
+import { ComposableStablePool } from '../types/ComposableStablePoolFactory/ComposableStablePool';
 
 function createWeightedLikePool(event: PoolCreated, poolType: string, poolTypeVersion: i32 = 1): string | null {
   let poolAddress: Address = event.params.pool;


### PR DESCRIPTION
# Description

Protocol fee cache attributes have not been set in some pools because the `ProtocolFeePercentageCacheUpdated` event is emitted before the `PoolCreated`. This PR adds on-chain calls to get the values on the pool creation - I opted to duplicate some code instead of creating confusion with the ABIs.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas

