### PR TITLE
Add FXPoolFactory & FX token addresses for Avalanche

### DIFF
--- a/assets/avalanche.json
+++ b/assets/avalanche.json
@@ -19,6 +19,10 @@
       {
         "address": "0xd586E7F844cEa2F87f50152665BCbc2C279D8d70",
         "symbol": "DAI"
+      },
+      {
+        "address": "0xC891EB4cbdEFf6e073e859e987815Ed1505c2ACD",
+        "symbol": "EUROC"
       }
     ],
     "pricingAssets": [

--- a/assets/avalanche.json
+++ b/assets/avalanche.json
@@ -30,6 +30,26 @@
         "address": "0xB31f66AA3C1e785363F0875A1B74E27b85FD66c7", 
         "symbol": "wAVAX"
       }
+    ],
+    "fxAssets": [
+      {
+        "address": "0xB97EF9Ef8734C71904D8002F8b6Bc66Dd9c48a6E",
+        "symbol": "USDC"
+      },
+      {
+        "address": "0xC891EB4cbdEFf6e073e859e987815Ed1505c2ACD",
+        "symbol": "EUROC"
+      }
+    ],
+    "fxAggregators": [
+      {
+        "address": "0xfBd998938f8f7210eEC3D1e12E80A10972F02aEd",
+        "symbol": "USDC-USD"
+      },
+      {
+        "address": "0x95Edda00bCE60f99Fb0bE38fE500eBd879AB651a",
+        "symbol": "EUR-USD"
+      }
     ]
   }
   

--- a/networks.yaml
+++ b/networks.yaml
@@ -644,6 +644,9 @@ avalanche:
   ERC4626LinearPoolV4Factory:
     address: "0x4507d91Cd2C0D51D9B4F30Bf0B93AFC938A70BA5"
     startBlock: 29513456
+  FXPoolFactory:
+    address: "0x81fE9e5B28dA92aE949b705DfDB225f7a7cc5134"
+    startBlock: 32585313
 basegoerli:
   network: base-testnet
   Vault:


### PR DESCRIPTION
# Description

Xave is constantly adding support for new stablecoins to power FX on DeFi, and today we’re excited to announce the launch of our EUROC:USDC FXPool on Avalanche.

This PR exposes our FXPools on Avalanche to Balancer subgraph.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [x] Other

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas

