### PR TITLE
FXPool totalLiquidity computation

### DIFF
--- a/assets/avalanche.json
+++ b/assets/avalanche.json
@@ -19,10 +19,6 @@
       {
         "address": "0xd586E7F844cEa2F87f50152665BCbc2C279D8d70",
         "symbol": "DAI"
-      },
-      {
-        "address": "0xC891EB4cbdEFf6e073e859e987815Ed1505c2ACD",
-        "symbol": "EUROC"
       }
     ],
     "pricingAssets": [


### PR DESCRIPTION
# Description

We noticed that the `totalLiquidity` the subgraph returns is lower than the value that `FXPool.liquidity()` call returns. We believe this is because of how the pool token price is computed.

This PR makes use of the `latestFXPrice` (off-chain FX price from chainlink oracles) by introducing a new `valueInFX()` function completely bypassing the logic inside `valueInUSD()` for computing the token value for **FXPools** only (other pools will remain to use `valueInUSD()`).

**Minor:**
We also removed `EUROC` from Avalanche stable assets (which we incorrectly added in the previous PR)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [x] Other

## How should this be tested?

Changes deployed to our test subgraph:
https://thegraph.com/hosted-service/subgraph/xave-finance/balancer-v2-avalanche

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
