### PR TITLE
fix managed pools liquidity

### DIFF
--- a/src/mappings/helpers/pools.ts
+++ b/src/mappings/helpers/pools.ts
@@ -46,6 +46,7 @@ export function hasVirtualSupply(pool: Pool): boolean {
     pool.poolType == PoolType.SiloLinear ||
     pool.poolType == PoolType.YearnLinear ||
     pool.poolType == PoolType.StablePhantom ||
+    pool.poolType == PoolType.Managed ||
     isComposableStablePool(pool)
   );
 }


### PR DESCRIPTION
# Description

Managed pools are considering pre-minted BPTs towards the pool's TVL because we missed adding it to the `hasVirtualSupply()` function.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
