### PR TITLE
Update avax deployment

### DIFF
--- a/assets/avalanche.json
+++ b/assets/avalanche.json
@@ -33,6 +33,14 @@
       {
         "address": "0xB31f66AA3C1e785363F0875A1B74E27b85FD66c7", 
         "symbol": "wAVAX"
+      },
+      {
+        "address": "0x7275c131b1F67e8B53b4691F92B0E35A4c1C6e22",
+        "symbol": "bb-a-WAVAX-V3"
+      },
+      {
+        "address": "0xa1D14d922a575232066520EDA11E27760946c991",
+        "symbol": "bb-a-USD-V3"
       }
     ],
     "fxAssets": [

--- a/curation-contracts/deployments/avalanche.json
+++ b/curation-contracts/deployments/avalanche.json
@@ -1,0 +1,3 @@
+{
+  "EventEmitter": "0xf04378a3ff97b3f979a46f91f9b2d5A1D2394773"
+}

--- a/networks.yaml
+++ b/networks.yaml
@@ -622,6 +622,9 @@ optimism:
     startBlock: 97253023
 avalanche:
   network: avalanche
+  EventEmitter:
+    address: "0xf04378a3ff97b3f979a46f91f9b2d5A1D2394773"
+    startBlock: 33336746
   Vault:
     address: "0xBA12222222228d8Ba445958a75a0704d566BF2C8"
     startBlock: 26386141


### PR DESCRIPTION
# Description

Adds `EventEmitter` contract and sets `bbaWAVAX` and `bbaUSD` as pricing assets. This PR will only trigger a deployment on Avalanche.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas

### Merges to `dev`
- [x] I have checked that the graft base is not a pruned deployment
