### PR TITLE
remove bpts from balancer's liquidity

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -31,6 +31,7 @@ type Pool @entity {
   totalSwapVolume: BigDecimal!
   totalSwapFee: BigDecimal!
   totalLiquidity: BigDecimal!
+  totalLiquiditySansBPT: BigDecimal # TODO: make mandatory at next full sync
   totalShares: BigDecimal!
   totalProtocolFee: BigDecimal # TODO: make mandatory at next full sync
   createTime: Int!

--- a/src/mappings/helpers/misc.ts
+++ b/src/mappings/helpers/misc.ts
@@ -117,6 +117,7 @@ export function newPoolEntity(poolId: string): Pool {
   pool.totalSwapFee = ZERO_BD;
   pool.totalProtocolFee = ZERO_BD;
   pool.totalLiquidity = ZERO_BD;
+  pool.totalLiquiditySansBPT = ZERO_BD;
   pool.totalShares = ZERO_BD;
   pool.swapsCount = BigInt.fromI32(0);
   pool.holdersCount = BigInt.fromI32(0);


### PR DESCRIPTION
# Description


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [x] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

- [x] [Avalanche TVL](https://api.thegraph.com/subgraphs/name/mendesfabio/balancer-avalanche-v2/graphql?query=%7B%0A%09balancers+%7B%0A%09++totalLiquidity%0A%09%7D%0A++pools(%0A++++where:+%7B%0A++++++totalLiquidity_gt:+1000%0A++++%7D%0A++)+%7B%0A++++symbol%0A++++totalLiquidity%0A++++totalLiquiditySansBPT%0A++%7D%0A%7D%0A)

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas

