### PR TITLE
fix pre-minted bpts pricing

### DIFF
--- a/networks.yaml
+++ b/networks.yaml
@@ -1,11 +1,11 @@
 mainnet:
   network: mainnet
   graft:
-    # Mar 30
-    # block: 16938731
+    # Aug 27
+    block: 18004633
     # always make sure the base subgraph has not been pruned
     # it should be possible to run time travel queries on it going back to the vault's startBlock
-    # base: QmQnxRrmWbFUTfLFeHv8qi6Tf7ZMfrUVqoK7tvbF1tapbM
+    base: QmSCp25Ep62sPErV2NjY9LWZyBnqGKsCYaDBXkXfWzBxGw
   EventEmitter:
     address: "0x1ACfEEA57d2ac674d7E65964f155AB9348A6C290"
     startBlock: 16419620
@@ -221,16 +221,16 @@ goerli:
 polygon:
   network: matic
   graft:
-    # Aug 11
-    block: 46175000
+    # Aug 27
+    block: 46810000
     # this will be the base of the unpruned deployment, so make sure it has not been pruned
     # it should be possible to run time travel queries on it going back to the vault's startBlock
-    base: QmTqmUs4xp7zQkdfPB4jNv5fZfeF7jp9iKjZ3FGvRpYqUz
+    base: QmdotN5vu9VXZZvHNJqugkJ2ZCHFQmx8eLe3UbDvNUxzHJ
   graft_pruned:
-    # Aug 11
-    block: 46175000
+    # Aug 27
+    block: 46810000
     # this will be the base of the pruned deployment, so it is ok if it is a pruned subgraph
-    base: QmRkFHajzzSbLX1yvMV9vrYL9XEaiuSb2dmGV1eyEX43VN
+    base: QmULAfA3eS5yojxeSR2KmbyuiwCGYPjymsFcpa6uYsu6CJ
   EventEmitter:
     address: "0xcdcECFa416EE3022030E707dC3EA13a8997D74c8"
     startBlock: 38152461
@@ -345,11 +345,11 @@ polygon:
 arbitrum:
   network: arbitrum-one
   graft:
-    # Aug 8
-    block: 119340000
+    # Aug 27
+    block: 125400000
     # always make sure the base subgraph has not been pruned
     # it should be possible to run time travel queries on it going back to the vault's startBlock
-    base: QmVGGmBgze1tSc85fG9RpfGKSX1C5RjmWo2EpffEZyyKHa
+    base: QmSRfL652VGbQ1MnfFgGQdsxuLwdNebKoiLYn4Ph49XsWU
   EventEmitter:
     address: "0x8f32D631093B5418d0546f77442c5fa66187E59D"
     startBlock: 53475240

--- a/src/mappings/pricing.ts
+++ b/src/mappings/pricing.ts
@@ -177,7 +177,9 @@ export function updatePoolLiquidity(poolId: string, block_number: BigInt, timest
   }
 
   // update BPT price
-  updateBptPrice(pool);
+  if (newPoolLiquidity.gt(MIN_POOL_LIQUIDITY)) {
+    updateBptPrice(pool);
+  }
 
   // Create or update pool daily snapshot
   createPoolSnapshot(pool, timestamp.toI32());

--- a/src/mappings/vault.ts
+++ b/src/mappings/vault.ts
@@ -572,7 +572,8 @@ export function handleSwapEvent(event: SwapEvent): void {
 
   let swapId = transactionHash.toHexString().concat(logIndex.toString());
 
-  if (poolAddress == tokenInAddress || poolAddress == tokenOutAddress) {
+  const isJoinExitSwap = poolAddress == tokenInAddress || poolAddress == tokenOutAddress;
+  if (isJoinExitSwap) {
     if (isComposableStablePool(pool)) {
       let tokenAddresses = pool.tokensList;
       let balances: BigInt[] = [];
@@ -668,7 +669,12 @@ export function handleSwapEvent(event: SwapEvent): void {
   let blockNumber = event.block.number;
   let tokenInWeight = poolTokenIn.weight;
   let tokenOutWeight = poolTokenOut.weight;
-  if (isPricingAsset(tokenInAddress) && pool.totalLiquidity.gt(MIN_POOL_LIQUIDITY) && valueUSD.gt(MIN_SWAP_VALUE_USD)) {
+  if (
+    !isJoinExitSwap &&
+    isPricingAsset(tokenInAddress) &&
+    pool.totalLiquidity.gt(MIN_POOL_LIQUIDITY) &&
+    valueUSD.gt(MIN_SWAP_VALUE_USD)
+  ) {
     let tokenPriceId = getTokenPriceId(poolId.toHex(), tokenOutAddress, tokenInAddress, blockNumber);
     let tokenPrice = new TokenPrice(tokenPriceId);
     //tokenPrice.poolTokenId = getPoolTokenId(poolId, tokenOutAddress);
@@ -693,6 +699,7 @@ export function handleSwapEvent(event: SwapEvent): void {
     updateLatestPrice(tokenPrice, event.block.timestamp);
   }
   if (
+    !isJoinExitSwap &&
     isPricingAsset(tokenOutAddress) &&
     pool.totalLiquidity.gt(MIN_POOL_LIQUIDITY) &&
     valueUSD.gt(MIN_SWAP_VALUE_USD)


### PR DESCRIPTION
# Description

Some BPTs have been incorrectly priced after the vulnerability announced by Balancer. This PR fixes that by disallowing pricing on join/exit swaps and instead only pricing BPTs based on the value of the underlying tokens. To make it consistent with the pricing on swaps, only pools with TVL greater than `MIN_POOL_LIQUIDITY` will price BPTs.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

- [x] Compare pre/post-exploit data of [production](https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-v2/graphql?query=%7B%0A%09current:+balancers+%7B%0A%09++totalLiquidity%0A++++totalSwapVolume%0A++++pools(%0A++++++orderBy:+totalSwapVolume%0A++++++orderDirection:+desc%0A++++++first:+3%0A++++)+%7B%0A++++++id%0A++++++symbol%0A++++++totalLiquidity%0A++++++totalSwapVolume%0A++++%7D%0A%09%7D%0A++pre_exploit:+balancers(%0A++++block:+%7B%0A++++++number:+18004633%0A++++%7D%0A++)+%7B%0A%09++totalLiquidity%0A++++totalSwapVolume%0A++++pools(%0A++++++orderBy:+totalSwapVolume%0A++++++orderDirection:+desc%0A++++++first:+3%0A++++)+%7B%0A++++++id%0A++++++symbol%0A++++++totalLiquidity%0A++++++totalSwapVolume%0A++++%7D%0A%09%7D%0A%7D) vs. [fixed](https://api.thegraph.com/subgraphs/name/mendesfabio/balancer-v2/graphql?query=%7B%0A%09current:+balancers+%7B%0A%09++totalLiquidity%0A++++totalSwapVolume%0A++++pools(%0A++++++orderBy:+totalSwapVolume%0A++++++orderDirection:+desc%0A++++++first:+3%0A++++)+%7B%0A++++++id%0A++++++symbol%0A++++++totalLiquidity%0A++++++totalSwapVolume%0A++++%7D%0A%09%7D%0A++pre_exploit:+balancers(%0A++++block:+%7B%0A++++++number:+18004633%0A++++%7D%0A++)+%7B%0A%09++totalLiquidity%0A++++totalSwapVolume%0A++++pools(%0A++++++orderBy:+totalSwapVolume%0A++++++orderDirection:+desc%0A++++++first:+3%0A++++)+%7B%0A++++++id%0A++++++symbol%0A++++++totalLiquidity%0A++++++totalSwapVolume%0A++++%7D%0A%09%7D%0A%7D) Subgraphs.
- [x] Could run frontend locally and point it to my fixed Subgraph. I've done that -- below are some screenshots of charts that are now correctly working.

<img width="832" alt="image" src="https://github.com/balancer/balancer-subgraph-v2/assets/43360747/bca0844d-26ea-4563-a60d-1fc7b724b6e4">
<img width="826" alt="image" src="https://github.com/balancer/balancer-subgraph-v2/assets/43360747/8c1fa85c-2808-40a5-9b0c-ae07f19ef3b3">

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas

### Merges to `dev`
- [x] I have checked that the graft base is not a pruned deployment
