### PR TITLE
fix compute swap enabled function

### DIFF
--- a/networks.yaml
+++ b/networks.yaml
@@ -230,7 +230,7 @@ polygon:
     # Aug 27
     block: 46810000
     # this will be the base of the pruned deployment, so it is ok if it is a pruned subgraph
-    base: QmULAfA3eS5yojxeSR2KmbyuiwCGYPjymsFcpa6uYsu6CJ
+    base: QmdotN5vu9VXZZvHNJqugkJ2ZCHFQmx8eLe3UbDvNUxzHJ
   EventEmitter:
     address: "0xcdcECFa416EE3022030E707dC3EA13a8997D74c8"
     startBlock: 38152461

--- a/src/mappings/helpers/misc.ts
+++ b/src/mappings/helpers/misc.ts
@@ -462,7 +462,7 @@ export function computeCuratedSwapEnabled(
   internalSwapEnabled: boolean
 ): boolean {
   if (isPaused) return false;
-  if (!swapEnabledCurationSignal) return internalSwapEnabled;
+  if (swapEnabledCurationSignal == null) return internalSwapEnabled;
   return swapEnabledCurationSignal && internalSwapEnabled;
 }
 

--- a/src/mappings/helpers/misc.ts
+++ b/src/mappings/helpers/misc.ts
@@ -462,6 +462,7 @@ export function computeCuratedSwapEnabled(
   internalSwapEnabled: boolean
 ): boolean {
   if (isPaused) return false;
+  if (!swapEnabledCurationSignal) return internalSwapEnabled;
   return swapEnabledCurationSignal && internalSwapEnabled;
 }
 


### PR DESCRIPTION
# Description

`computeCuratedSwapEnabled` function doesn't work correctly if `swapEnabledCurationSignal` is null. This PR handles that case by simply returning `internalSwapEnabled`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas

### Merges to `dev`
- [x] I have checked that the graft base is not a pruned deployment
