### PR TITLE
Update GyroE pool factory type

### DIFF
--- a/networks.yaml
+++ b/networks.yaml
@@ -123,7 +123,7 @@ mainnet:
   ProtocolIdRegistry:
     address: "0xc3ccacE87f6d3A81724075ADcb5ddd85a8A1bB68"
     startBlock: 16719996
-  GyroEPoolFactory:
+  GyroEV2PoolFactory:
     address: "0x412a5B2e7a678471985542757A6855847D4931D5"
     startBlock: 17672894
 goerli:
@@ -617,7 +617,7 @@ optimism:
   ProtocolIdRegistry:
     address: "0x9805dcfD25e6De36bad8fe9D3Fe2c9b44B764102"
     startBlock: 77557576
-  GyroEPoolFactory:
+  GyroEV2PoolFactory:
     address: "0x9b683ca24b0e013512e2566b68704dbe9677413c"
     startBlock: 97253023
 avalanche:


### PR DESCRIPTION
GyroE pool factory on Optimism and Mainnet should have been labelled `GyroEV2PoolFactory`.