### PR TITLE
promote dev to prod

### DIFF
--- a/.github/workflows/graph-studio.yml
+++ b/.github/workflows/graph-studio.yml
@@ -5,131 +5,131 @@ on:
     branches: master
 
 jobs:
-  # deploy-studio-mainnet:
-  #   runs-on: ubuntu-latest
-  #   environment: graph
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - name: Install node
-  #       uses: actions/setup-node@v1
-  #       with:
-  #         node-version: 16
-  #     - name: Install
-  #       run: yarn --frozen-lockfile
-  #     - name: Assets
-  #       run: yarn generate-assets
-  #     - name: Codegen
-  #       run: yarn codegen
-  #     - name: Build
-  #       run: yarn build
-  #     - uses: gtaschuk/graph-deploy@v0.1.11
-  #       with:
-  #         graph_deploy_key: ${{secrets.GRAPH_DEPLOY_KEY}}
-  #         graph_version_label: ${GITHUB_SHA::8}
-  #         graph_subgraph_name: "balancer-v2"
-  #         graph_account: "balancer-labs"
-  #         graph_config_file: "subgraph.yaml"
-  #         graph_deploy_studio: true
-  # deploy-studio-base-testnet:
-  #   runs-on: ubuntu-latest
-  #   environment: graph
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - name: Install node
-  #       uses: actions/setup-node@v1
-  #       with:
-  #         node-version: 16
-  #     - name: Install
-  #       run: yarn --frozen-lockfile
-  #     - name: Assets
-  #       run: yarn generate-assets
-  #     - name: Codegen
-  #       run: yarn codegen
-  #     - name: Build
-  #       run: yarn build
-  #     - uses: gtaschuk/graph-deploy@v0.1.11
-  #       with:
-  #         graph_deploy_key: ${{secrets.GRAPH_DEPLOY_KEY}}
-  #         graph_version_label: ${GITHUB_SHA::8}
-  #         graph_subgraph_name: "balancer-base-testnet-v2"
-  #         graph_account: "balancer-labs"
-  #         graph_config_file: "subgraph.basegoerli.yaml"
-  #         graph_deploy_studio: true
-  # deploy-studio-sepolia:
-  #   runs-on: ubuntu-latest
-  #   environment: graph
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - name: Install node
-  #       uses: actions/setup-node@v1
-  #       with:
-  #         node-version: 16
-  #     - name: Install
-  #       run: yarn --frozen-lockfile
-  #     - name: Assets
-  #       run: yarn generate-assets sepolia
-  #     - name: Codegen
-  #       run: yarn codegen
-  #     - name: Build
-  #       run: yarn build
-  #     - uses: gtaschuk/graph-deploy@v0.1.11
-  #       with:
-  #         graph_deploy_key: ${{secrets.GRAPH_DEPLOY_KEY}}
-  #         graph_version_label: ${GITHUB_SHA::8}
-  #         graph_subgraph_name: "balancer-sepolia-v2"
-  #         graph_account: "balancer-labs"
-  #         graph_config_file: "subgraph.sepolia.yaml"
-  #         graph_deploy_studio: true
-  # deploy-studio-polygon-zkevm:
-  #   runs-on: ubuntu-latest
-  #   environment: graph
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - name: Install node
-  #       uses: actions/setup-node@v1
-  #       with:
-  #         node-version: 16
-  #     - name: Install
-  #       run: yarn --frozen-lockfile
-  #     - name: Assets
-  #       run: yarn generate-assets polygon-zkevm
-  #     - name: Codegen
-  #       run: yarn codegen
-  #     - name: Build
-  #       run: yarn build
-  #     - uses: gtaschuk/graph-deploy@v0.1.11
-  #       with:
-  #         graph_deploy_key: ${{secrets.GRAPH_DEPLOY_KEY}}
-  #         graph_version_label: ${GITHUB_SHA::8}
-  #         graph_subgraph_name: "balancer-polygon-zk-v2"
-  #         graph_account: "balancer-labs"
-  #         graph_config_file: "subgraph.polygon-zkevm.yaml"
-  #         graph_deploy_studio: true
-  # deploy-studio-base:
-  #   runs-on: ubuntu-latest
-  #   environment: graph
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - name: Install node
-  #       uses: actions/setup-node@v1
-  #       with:
-  #         node-version: 16
-  #     - name: Install
-  #       run: yarn --frozen-lockfile
-  #     - name: Assets
-  #       run: yarn generate-assets base
-  #     - name: Codegen
-  #       run: yarn codegen
-  #     - name: Build
-  #       run: yarn build
-  #     - uses: gtaschuk/graph-deploy@v0.1.11
-  #       with:
-  #         graph_deploy_key: ${{secrets.GRAPH_DEPLOY_KEY}}
-  #         graph_version_label: ${GITHUB_SHA::8}
-  #         graph_subgraph_name: "balancer-base-v2"
-  #         graph_account: "balancer-labs"
-  #         graph_config_file: "subgraph.base.yaml"
-  #         graph_deploy_studio: true
+  deploy-studio-mainnet:
+    runs-on: ubuntu-latest
+    environment: graph
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install node
+        uses: actions/setup-node@v1
+        with:
+          node-version: 16
+      - name: Install
+        run: yarn --frozen-lockfile
+      - name: Assets
+        run: yarn generate-assets
+      - name: Codegen
+        run: yarn codegen
+      - name: Build
+        run: yarn build
+      - uses: gtaschuk/graph-deploy@v0.1.11
+        with:
+          graph_deploy_key: ${{secrets.GRAPH_DEPLOY_KEY}}
+          graph_version_label: ${GITHUB_SHA::8}
+          graph_subgraph_name: "balancer-v2"
+          graph_account: "balancer-labs"
+          graph_config_file: "subgraph.yaml"
+          graph_deploy_studio: true
+  deploy-studio-base-testnet:
+    runs-on: ubuntu-latest
+    environment: graph
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install node
+        uses: actions/setup-node@v1
+        with:
+          node-version: 16
+      - name: Install
+        run: yarn --frozen-lockfile
+      - name: Assets
+        run: yarn generate-assets
+      - name: Codegen
+        run: yarn codegen
+      - name: Build
+        run: yarn build
+      - uses: gtaschuk/graph-deploy@v0.1.11
+        with:
+          graph_deploy_key: ${{secrets.GRAPH_DEPLOY_KEY}}
+          graph_version_label: ${GITHUB_SHA::8}
+          graph_subgraph_name: "balancer-base-testnet-v2"
+          graph_account: "balancer-labs"
+          graph_config_file: "subgraph.basegoerli.yaml"
+          graph_deploy_studio: true
+  deploy-studio-sepolia:
+    runs-on: ubuntu-latest
+    environment: graph
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install node
+        uses: actions/setup-node@v1
+        with:
+          node-version: 16
+      - name: Install
+        run: yarn --frozen-lockfile
+      - name: Assets
+        run: yarn generate-assets sepolia
+      - name: Codegen
+        run: yarn codegen
+      - name: Build
+        run: yarn build
+      - uses: gtaschuk/graph-deploy@v0.1.11
+        with:
+          graph_deploy_key: ${{secrets.GRAPH_DEPLOY_KEY}}
+          graph_version_label: ${GITHUB_SHA::8}
+          graph_subgraph_name: "balancer-sepolia-v2"
+          graph_account: "balancer-labs"
+          graph_config_file: "subgraph.sepolia.yaml"
+          graph_deploy_studio: true
+  deploy-studio-polygon-zkevm:
+    runs-on: ubuntu-latest
+    environment: graph
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install node
+        uses: actions/setup-node@v1
+        with:
+          node-version: 16
+      - name: Install
+        run: yarn --frozen-lockfile
+      - name: Assets
+        run: yarn generate-assets polygon-zkevm
+      - name: Codegen
+        run: yarn codegen
+      - name: Build
+        run: yarn build
+      - uses: gtaschuk/graph-deploy@v0.1.11
+        with:
+          graph_deploy_key: ${{secrets.GRAPH_DEPLOY_KEY}}
+          graph_version_label: ${GITHUB_SHA::8}
+          graph_subgraph_name: "balancer-polygon-zk-v2"
+          graph_account: "balancer-labs"
+          graph_config_file: "subgraph.polygon-zkevm.yaml"
+          graph_deploy_studio: true
+  deploy-studio-base:
+    runs-on: ubuntu-latest
+    environment: graph
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install node
+        uses: actions/setup-node@v1
+        with:
+          node-version: 16
+      - name: Install
+        run: yarn --frozen-lockfile
+      - name: Assets
+        run: yarn generate-assets base
+      - name: Codegen
+        run: yarn codegen
+      - name: Build
+        run: yarn build
+      - uses: gtaschuk/graph-deploy@v0.1.11
+        with:
+          graph_deploy_key: ${{secrets.GRAPH_DEPLOY_KEY}}
+          graph_version_label: ${GITHUB_SHA::8}
+          graph_subgraph_name: "balancer-base-v2"
+          graph_account: "balancer-labs"
+          graph_config_file: "subgraph.base.yaml"
+          graph_deploy_studio: true
 
 env:
   CI: true

--- a/.github/workflows/graph.yml
+++ b/.github/workflows/graph.yml
@@ -5,29 +5,29 @@ on:
     branches: master
 
 jobs:
-  # deploy-goerli:
-  #   runs-on: ubuntu-latest
-  #   environment: graph
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - name: Install node
-  #       uses: actions/setup-node@v1
-  #       with:
-  #         node-version: 16
-  #     - name: Install
-  #       run: yarn --frozen-lockfile
-  #     - name: Assets
-  #       run: yarn generate-assets goerli
-  #     - name: Codegen
-  #       run: yarn codegen
-  #     - name: Build
-  #       run: yarn build
-  #     - uses: balancer-labs/graph-deploy@v0.0.1
-  #       with:
-  #         graph_access_token: ${{secrets.GRAPH_ACCESS_TOKEN}}
-  #         graph_subgraph_name: "balancer-goerli-v2"
-  #         graph_account: "balancer-labs"
-  #         graph_config_file: "subgraph.goerli.yaml"
+  deploy-goerli:
+    runs-on: ubuntu-latest
+    environment: graph
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install node
+        uses: actions/setup-node@v1
+        with:
+          node-version: 16
+      - name: Install
+        run: yarn --frozen-lockfile
+      - name: Assets
+        run: yarn generate-assets goerli
+      - name: Codegen
+        run: yarn codegen
+      - name: Build
+        run: yarn build
+      - uses: balancer-labs/graph-deploy@v0.0.1
+        with:
+          graph_access_token: ${{secrets.GRAPH_ACCESS_TOKEN}}
+          graph_subgraph_name: "balancer-goerli-v2"
+          graph_account: "balancer-labs"
+          graph_config_file: "subgraph.goerli.yaml"
   deploy-mainnet:
     runs-on: ubuntu-latest
     environment: graph
@@ -97,121 +97,121 @@ jobs:
   #         graph_subgraph_name: "balancer-polygon-prune-v2"
   #         graph_account: "balancer-labs"
   #         graph_config_file: "subgraph.polygon.pruned.yaml"
-  # deploy-arbitrum:
-  #   runs-on: ubuntu-latest
-  #   environment: graph
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - name: Install node
-  #       uses: actions/setup-node@v1
-  #       with:
-  #         node-version: 16
-  #     - name: Install
-  #       run: yarn --frozen-lockfile
-  #     - name: Assets
-  #       run: yarn generate-assets arbitrum
-  #     - name: Codegen
-  #       run: yarn codegen
-  #     - name: Build
-  #       run: yarn build
-  #     - uses: balancer-labs/graph-deploy@v0.0.1
-  #       with:
-  #         graph_access_token: ${{secrets.GRAPH_ACCESS_TOKEN}}
-  #         graph_subgraph_name: "balancer-arbitrum-v2"
-  #         graph_account: "balancer-labs"
-  #         graph_config_file: "subgraph.arbitrum.yaml"
-  # deploy-gnosis:
-  #   runs-on: ubuntu-latest
-  #   environment: graph
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - name: Install node
-  #       uses: actions/setup-node@v1
-  #       with:
-  #         node-version: 16
-  #     - name: Install
-  #       run: yarn --frozen-lockfile
-  #     - name: Assets
-  #       run: yarn generate-assets gnosis
-  #     - name: Codegen
-  #       run: yarn codegen
-  #     - name: Build
-  #       run: yarn build
-  #     - uses: balancer-labs/graph-deploy@v0.0.1
-  #       with:
-  #         graph_access_token: ${{secrets.GRAPH_ACCESS_TOKEN}}
-  #         graph_subgraph_name: "balancer-gnosis-chain-v2"
-  #         graph_account: "balancer-labs"
-  #         graph_config_file: "subgraph.gnosis.yaml"
-  # deploy-bnb:
-  #   runs-on: ubuntu-latest
-  #   environment: graph
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - name: Install node
-  #       uses: actions/setup-node@v1
-  #       with:
-  #         node-version: 16
-  #     - name: Install
-  #       run: yarn --frozen-lockfile
-  #     - name: Assets
-  #       run: yarn generate-assets bnb
-  #     - name: Codegen
-  #       run: yarn codegen
-  #     - name: Build
-  #       run: yarn build
-  #     - uses: balancer-labs/graph-deploy@v0.0.1
-  #       with:
-  #         graph_access_token: ${{secrets.GRAPH_ACCESS_TOKEN}}
-  #         graph_subgraph_name: "balancer-bnbchain-v2"
-  #         graph_account: "balancer-labs"
-  #         graph_config_file: "subgraph.bnb.yaml"
-  # deploy-avalanche:
-  #   runs-on: ubuntu-latest
-  #   environment: graph
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - name: Install node
-  #       uses: actions/setup-node@v1
-  #       with:
-  #         node-version: 16
-  #     - name: Install
-  #       run: yarn --frozen-lockfile
-  #     - name: Assets
-  #       run: yarn generate-assets avalanche
-  #     - name: Codegen
-  #       run: yarn codegen
-  #     - name: Build
-  #       run: yarn build
-  #     - uses: balancer-labs/graph-deploy@v0.0.1
-  #       with:
-  #         graph_access_token: ${{secrets.GRAPH_ACCESS_TOKEN}}
-  #         graph_subgraph_name: "balancer-avalanche-v2"
-  #         graph_account: "balancer-labs"
-  #         graph_config_file: "subgraph.avalanche.yaml"
-  # deploy-optimism:
-  #   runs-on: ubuntu-latest
-  #   environment: graph
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - name: Install node
-  #       uses: actions/setup-node@v1
-  #       with:
-  #         node-version: 16
-  #     - name: Install
-  #       run: yarn --frozen-lockfile
-  #     - name: Assets
-  #       run: yarn generate-assets optimism
-  #     - name: Codegen
-  #       run: yarn codegen
-  #     - name: Build
-  #       run: yarn build
-  #     - uses: balancer-labs/graph-deploy@v0.0.1
-  #       with:
-  #         graph_access_token: ${{secrets.GRAPH_ACCESS_TOKEN}}
-  #         graph_subgraph_name: "balancer-optimism-v2"
-  #         graph_account: "balancer-labs"
-  #         graph_config_file: "subgraph.optimism.yaml"
+  deploy-arbitrum:
+    runs-on: ubuntu-latest
+    environment: graph
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install node
+        uses: actions/setup-node@v1
+        with:
+          node-version: 16
+      - name: Install
+        run: yarn --frozen-lockfile
+      - name: Assets
+        run: yarn generate-assets arbitrum
+      - name: Codegen
+        run: yarn codegen
+      - name: Build
+        run: yarn build
+      - uses: balancer-labs/graph-deploy@v0.0.1
+        with:
+          graph_access_token: ${{secrets.GRAPH_ACCESS_TOKEN}}
+          graph_subgraph_name: "balancer-arbitrum-v2"
+          graph_account: "balancer-labs"
+          graph_config_file: "subgraph.arbitrum.yaml"
+  deploy-gnosis:
+    runs-on: ubuntu-latest
+    environment: graph
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install node
+        uses: actions/setup-node@v1
+        with:
+          node-version: 16
+      - name: Install
+        run: yarn --frozen-lockfile
+      - name: Assets
+        run: yarn generate-assets gnosis
+      - name: Codegen
+        run: yarn codegen
+      - name: Build
+        run: yarn build
+      - uses: balancer-labs/graph-deploy@v0.0.1
+        with:
+          graph_access_token: ${{secrets.GRAPH_ACCESS_TOKEN}}
+          graph_subgraph_name: "balancer-gnosis-chain-v2"
+          graph_account: "balancer-labs"
+          graph_config_file: "subgraph.gnosis.yaml"
+  deploy-bnb:
+    runs-on: ubuntu-latest
+    environment: graph
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install node
+        uses: actions/setup-node@v1
+        with:
+          node-version: 16
+      - name: Install
+        run: yarn --frozen-lockfile
+      - name: Assets
+        run: yarn generate-assets bnb
+      - name: Codegen
+        run: yarn codegen
+      - name: Build
+        run: yarn build
+      - uses: balancer-labs/graph-deploy@v0.0.1
+        with:
+          graph_access_token: ${{secrets.GRAPH_ACCESS_TOKEN}}
+          graph_subgraph_name: "balancer-bnbchain-v2"
+          graph_account: "balancer-labs"
+          graph_config_file: "subgraph.bnb.yaml"
+  deploy-avalanche:
+    runs-on: ubuntu-latest
+    environment: graph
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install node
+        uses: actions/setup-node@v1
+        with:
+          node-version: 16
+      - name: Install
+        run: yarn --frozen-lockfile
+      - name: Assets
+        run: yarn generate-assets avalanche
+      - name: Codegen
+        run: yarn codegen
+      - name: Build
+        run: yarn build
+      - uses: balancer-labs/graph-deploy@v0.0.1
+        with:
+          graph_access_token: ${{secrets.GRAPH_ACCESS_TOKEN}}
+          graph_subgraph_name: "balancer-avalanche-v2"
+          graph_account: "balancer-labs"
+          graph_config_file: "subgraph.avalanche.yaml"
+  deploy-optimism:
+    runs-on: ubuntu-latest
+    environment: graph
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install node
+        uses: actions/setup-node@v1
+        with:
+          node-version: 16
+      - name: Install
+        run: yarn --frozen-lockfile
+      - name: Assets
+        run: yarn generate-assets optimism
+      - name: Codegen
+        run: yarn codegen
+      - name: Build
+        run: yarn build
+      - uses: balancer-labs/graph-deploy@v0.0.1
+        with:
+          graph_access_token: ${{secrets.GRAPH_ACCESS_TOKEN}}
+          graph_subgraph_name: "balancer-optimism-v2"
+          graph_account: "balancer-labs"
+          graph_config_file: "subgraph.optimism.yaml"
 
 env:
   CI: true

--- a/.github/workflows/graph.yml
+++ b/.github/workflows/graph.yml
@@ -51,52 +51,52 @@ jobs:
           graph_subgraph_name: "balancer-v2"
           graph_account: "balancer-labs"
           graph_config_file: "subgraph.yaml"
-  # deploy-polygon:
-  #   runs-on: ubuntu-latest
-  #   environment: graph
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - name: Install node
-  #       uses: actions/setup-node@v1
-  #       with:
-  #         node-version: 16
-  #     - name: Install
-  #       run: yarn --frozen-lockfile
-  #     - name: Assets
-  #       run: yarn generate-assets polygon
-  #     - name: Codegen
-  #       run: yarn codegen
-  #     - name: Build
-  #       run: yarn build
-  #     - uses: balancer-labs/graph-deploy@v0.0.1
-  #       with:
-  #         graph_access_token: ${{secrets.GRAPH_ACCESS_TOKEN}}
-  #         graph_subgraph_name: "balancer-polygon-v2"
-  #         graph_account: "balancer-labs"
-  #         graph_config_file: "subgraph.polygon.yaml"
-  # deploy-polygon-pruned:
-  #   runs-on: ubuntu-latest
-  #   environment: graph
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - name: Install node
-  #       uses: actions/setup-node@v1
-  #       with:
-  #         node-version: 16
-  #     - name: Install
-  #       run: yarn --frozen-lockfile
-  #     - name: Assets
-  #       run: yarn generate-assets polygon-prune
-  #     - name: Codegen
-  #       run: yarn codegen
-  #     - name: Build
-  #       run: yarn build
-  #     - uses: balancer-labs/graph-deploy@v0.0.1
-  #       with:
-  #         graph_access_token: ${{secrets.GRAPH_ACCESS_TOKEN}}
-  #         graph_subgraph_name: "balancer-polygon-prune-v2"
-  #         graph_account: "balancer-labs"
-  #         graph_config_file: "subgraph.polygon.pruned.yaml"
+  deploy-polygon:
+    runs-on: ubuntu-latest
+    environment: graph
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install node
+        uses: actions/setup-node@v1
+        with:
+          node-version: 16
+      - name: Install
+        run: yarn --frozen-lockfile
+      - name: Assets
+        run: yarn generate-assets polygon
+      - name: Codegen
+        run: yarn codegen
+      - name: Build
+        run: yarn build
+      - uses: balancer-labs/graph-deploy@v0.0.1
+        with:
+          graph_access_token: ${{secrets.GRAPH_ACCESS_TOKEN}}
+          graph_subgraph_name: "balancer-polygon-v2"
+          graph_account: "balancer-labs"
+          graph_config_file: "subgraph.polygon.yaml"
+  deploy-polygon-pruned:
+    runs-on: ubuntu-latest
+    environment: graph
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install node
+        uses: actions/setup-node@v1
+        with:
+          node-version: 16
+      - name: Install
+        run: yarn --frozen-lockfile
+      - name: Assets
+        run: yarn generate-assets polygon-prune
+      - name: Codegen
+        run: yarn codegen
+      - name: Build
+        run: yarn build
+      - uses: balancer-labs/graph-deploy@v0.0.1
+        with:
+          graph_access_token: ${{secrets.GRAPH_ACCESS_TOKEN}}
+          graph_subgraph_name: "balancer-polygon-prune-v2"
+          graph_account: "balancer-labs"
+          graph_config_file: "subgraph.polygon.pruned.yaml"
   deploy-arbitrum:
     runs-on: ubuntu-latest
     environment: graph

--- a/networks.yaml
+++ b/networks.yaml
@@ -1,11 +1,11 @@
 mainnet:
   network: mainnet
   graft:
-    # Aug 27
-    block: 18004633
+    # GyroE V2
+    block: 17672894
     # always make sure the base subgraph has not been pruned
     # it should be possible to run time travel queries on it going back to the vault's startBlock
-    base: QmSCp25Ep62sPErV2NjY9LWZyBnqGKsCYaDBXkXfWzBxGw
+    base: QmYA3WuYqS74BYkKbfE4oWrv12YU4RC9FnYaPWF5YMavaj
   EventEmitter:
     address: "0x1ACfEEA57d2ac674d7E65964f155AB9348A6C290"
     startBlock: 16419620


### PR DESCRIPTION
# Description

- #514 
- [uncomment all prod gh actions](https://github.com/balancer/balancer-subgraph-v2/pull/516/commits/84b66ed5cf238aa98217b31b75a5be6075bcb0b3)

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

- [x] [GyroE pools have correct `poolTypeVersion`](https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-v2-beta/graphql?query=%7B%0A%09pools(%0A++++where:+%7B%0A++++++poolType:+%22GyroE%22%0A++++%7D%0A++)+%7B%0A%09++id%0A++++poolTypeVersion%0A%09%7D%0A%7D)
- [x] [Balancer overall metrics have been fixed on Polygon](https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-polygon-v2-beta/graphql?query=%7B%0A%09balancers+%7B%0A%09++totalLiquidity%0A++++totalSwapVolume%0A%09%7D%0A%7D%0A)

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas

### `dev` -> `master`
- [x] I have [checked](https://balancer.github.io/balancer-subgraph-v2/status.html) that all beta deployments have synced
- [x] I have [checked](https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-polygon-prune-v2-beta/graphql?query=%0A%7B%0A++balancers%28block%3A%7Bnumber%3A1%7D%29%7B%0A++++id%0A++%7D%0A%7D) that the earliest block in the polygon pruned deployment is [47473728, Sep-13-2023 01:22:02 AM](https://polygonscan.com/block/47473728)
  - [x] The earliest block is more than 24 hours old
- [x] I have checked that core metrics are the same in the beta and production deployments

