### PR TITLE
New FXPool Polygon tokens & oracles

### DIFF
--- a/assets/polygon.json
+++ b/assets/polygon.json
@@ -59,6 +59,14 @@
     {
       "address": "0xE111178A87A3BFf0c8d18DECBa5798827539Ae99",
       "symbol":  "EURS"
+    },
+    {
+      "address": "0xE6A537a407488807F0bbeb0038B79004f19DDDFb",
+      "symbol":  "BRLA"
+    },
+    {
+      "address": "0xC8bB8eDa94931cA2F20EF43eA7dBD58E68400400",
+      "symbol":  "VNXAU"
     }
   ],
   "fxAggregators": [
@@ -77,6 +85,14 @@
     {
       "address": "0x310990E8091b5cF083fA55F500F140CFBb959016",
       "symbol": "EURS-USD"
+    },
+    {
+      "address": "0xB90DA3ff54C3ED09115abf6FbA0Ff4645586af2c",
+      "symbol": "BRL-USD"
+    },
+    {
+      "address": "0x0C466540B2ee1a31b441671eac0ca886e051E410",
+      "symbol": "XAU-USD"
     }
   ]
 }

--- a/assets/polygon.json
+++ b/assets/polygon.json
@@ -87,11 +87,11 @@
       "symbol": "EURS-USD"
     },
     {
-      "address": "0xB90DA3ff54C3ED09115abf6FbA0Ff4645586af2c",
+      "address": "0x6DBd1be1a83005d26b582D61937b406300B05A8F",
       "symbol": "BRL-USD"
     },
     {
-      "address": "0x0C466540B2ee1a31b441671eac0ca886e051E410",
+      "address": "0x704179beB09282EaEf98CA8aaa443C1E273eBBc2",
       "symbol": "XAU-USD"
     }
   ]


### PR DESCRIPTION
# Description

Xave is constantly adding support for new stablecoins to power FX on DeFi, and today we’re excited to announce the incoming launch of our BRLA:USDC and VNXAU:USDC FXPool on Polygon.

This PR adds BRLA and VNXAU token and oracle addresses to the Polygon assets file - this is needed in order to compute `Token.latestFXPrice` which is then used on balancer-sor to estimate the trades.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [x] Other

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
