### PR TITLE
fix weighted v2+ rate providers

### DIFF
--- a/src/mappings/poolFactory.ts
+++ b/src/mappings/poolFactory.ts
@@ -110,8 +110,8 @@ function createWeightedLikePool(event: PoolCreated, poolType: string, poolTypeVe
   // Load pool with initial weights
   updatePoolWeights(poolId.toHexString());
 
-  // Create PriceRateProvider entities for WeightedPoolV2
-  if (poolType == PoolType.Weighted && poolTypeVersion == 2) {
+  // Create PriceRateProvider entities for WeightedPoolV2+
+  if (poolType == PoolType.Weighted && poolTypeVersion >= 2) {
     setPriceRateProviders(poolId.toHex(), poolAddress, tokens);
   }
 


### PR DESCRIPTION
# Description

`setPriceRateProviders` is only being called for WeightedV2 pools when it should be for `poolTypeVersion` >= 2.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
