### PR TITLE
latestFXPrice computation update for FX Pools

### DIFF
--- a/assets.handlebars
+++ b/assets.handlebars
@@ -7,8 +7,7 @@ import { Address } from '@graphprotocol/graph-ts';
 class Assets {
   public stableAssets: Address[];
   public pricingAssets: Address[];
-  public fxAssets: Address[];
-  public fxAggregators: Address[];
+  public fxAssetAggregators: Address[][];
 }
 
 {{#each stableAssets}}
@@ -26,14 +25,12 @@ export const assets: Assets = {
     Address.fromString('{{address}}'), // {{symbol}}
     {{/each}}
   ],
-  fxAssets: [
-    {{#each fxAssets}}
-    Address.fromString('{{address}}'), // {{symbol}}
-    {{/each}}
-  ],
-  fxAggregators: [
-    {{#each fxAggregators}}
-    Address.fromString('{{address}}'), // {{symbol}}
+  fxAssetAggregators: [
+    {{#each fxAssetAggregators}}
+    [
+      Address.fromString('{{asset}}'), // {{assetSymbol}}
+      Address.fromString('{{aggregator}}'), // {{aggregatorSymbol}}
+    ],
     {{/each}}
   ],
 };

--- a/assets/avalanche.json
+++ b/assets/avalanche.json
@@ -39,24 +39,24 @@
         "symbol": "bb-a-USD-V3"
       }
     ],
-    "fxAssets": [
+    "fxAssetAggregators": [
       {
-        "address": "0xB97EF9Ef8734C71904D8002F8b6Bc66Dd9c48a6E",
-        "symbol": "USDC"
+        "asset": "0xB97EF9Ef8734C71904D8002F8b6Bc66Dd9c48a6E",
+        "assetSymbol": "USDC",
+        "aggregator": "0xfBd998938f8f7210eEC3D1e12E80A10972F02aEd",
+        "aggregatorSymbol": "USDC/USD"
       },
       {
-        "address": "0xC891EB4cbdEFf6e073e859e987815Ed1505c2ACD",
-        "symbol": "EUROC"
-      }
-    ],
-    "fxAggregators": [
-      {
-        "address": "0xfBd998938f8f7210eEC3D1e12E80A10972F02aEd",
-        "symbol": "USDC-USD"
+        "asset": "0xC891EB4cbdEFf6e073e859e987815Ed1505c2ACD",
+        "assetSymbol": "EUROC",
+        "aggregator": "0x95Edda00bCE60f99Fb0bE38fE500eBd879AB651a",
+        "aggregatorSymbol": "EUR/USD"
       },
       {
-        "address": "0x95Edda00bCE60f99Fb0bE38fE500eBd879AB651a",
-        "symbol": "EUR-USD"
+        "asset": "0x7678e162f38ec9ef2Bfd1d0aAF9fd93355E5Fa0b",
+        "assetSymbol": "VEUR",
+        "aggregator": "0x95Edda00bCE60f99Fb0bE38fE500eBd879AB651a",
+        "aggregatorSymbol": "EUR/USD"
       }
     ]
   }

--- a/assets/avalanche.json
+++ b/assets/avalanche.json
@@ -57,6 +57,12 @@
         "assetSymbol": "VEUR",
         "aggregator": "0x95Edda00bCE60f99Fb0bE38fE500eBd879AB651a",
         "aggregatorSymbol": "EUR/USD"
+      },
+      {
+        "asset": "0x228a48df6819CCc2eCa01e2192ebAFfFdAD56c19",
+        "assetSymbol": "VCHF",
+        "aggregator": "0xA418573AB5226711c8564Eeb449c3618ABFaf677",
+        "aggregatorSymbol": "CHF/USD"
       }
     ]
   }

--- a/assets/mainnet.json
+++ b/assets/mainnet.json
@@ -95,40 +95,30 @@
       "symbol": "bb-a-WETH-V3"
     }
   ],
-  "fxAssets": [
+  "fxAssetAggregators": [
     {
-      "address": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
-      "symbol": "USDC"
+      "asset": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+      "assetSymbol": "USDC",
+      "aggregator": "0x789190466E21a8b78b8027866CBBDc151542A26C",
+      "aggregatorSymbol": "USDC/USD"
     },
     {
-      "address": "0x70e8dE73cE538DA2bEEd35d14187F6959a8ecA96",
-      "symbol": "XSGD"
+      "asset": "0x70e8dE73cE538DA2bEEd35d14187F6959a8ecA96",
+      "assetSymbol": "XSGD",
+      "aggregator": "0xc96129C796F03bb21AC947EfC5329CD1F560305B",
+      "aggregatorSymbol": "SGD/USD"
     },
     {
-      "address": "0x6B175474E89094C44Da98b954EedeAC495271d0F",
-      "symbol": "DAI"
+      "asset": "0x6B175474E89094C44Da98b954EedeAC495271d0F",
+      "assetSymbol": "DAI",
+      "aggregator": "0xDEc0a100eaD1fAa37407f0Edc76033426CF90b82",
+      "aggregatorSymbol": "DAI/USD"
     },
     {
-      "address": "0xdB25f211AB05b1c97D595516F45794528a807ad8",
-      "symbol":  "EURS"
-    }
-  ],
-  "fxAggregators": [
-    {
-      "address": "0x789190466E21a8b78b8027866CBBDc151542A26C",
-      "symbol": "USDC-USD"
-    },
-    {
-      "address": "0xc96129C796F03bb21AC947EfC5329CD1F560305B",
-      "symbol": "XSGD-USD"
-    },
-    {
-      "address": "0xDEc0a100eaD1fAa37407f0Edc76033426CF90b82",
-      "symbol": "DAI-USD"
-    },
-    {
-      "address": "0x02F878A94a1AE1B15705aCD65b5519A46fe3517e",
-      "symbol": "EURS-USD"
+      "asset": "0xdB25f211AB05b1c97D595516F45794528a807ad8",
+      "assetSymbol": "EURS",
+      "aggregator": "0x02F878A94a1AE1B15705aCD65b5519A46fe3517e",
+      "aggregatorSymbol": "EUR/USD"
     }
   ]
 }

--- a/assets/polygon.json
+++ b/assets/polygon.json
@@ -43,56 +43,54 @@
       "symbol": "bb-am-USD"
     }
   ],
-  "fxAssets": [
+  "fxAssetAggregators": [
     {
-      "address": "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174",
-      "symbol": "USDC"
+      "asset": "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174",
+      "assetSymbol": "USDC",
+      "aggregator": "0xf9c53A834F60cBbE40E27702276fBc0819B3aFAD",
+      "aggregatorSymbol": "USDC/USD"
     },
     {
-      "address": "0xDC3326e71D45186F113a2F448984CA0e8D201995",
-      "symbol": "XSGD"
+      "asset": "0xDC3326e71D45186F113a2F448984CA0e8D201995",
+      "assetSymbol": "XSGD",
+      "aggregator": "0x45ede0Ea5cBbE380C663C7C3015Cc7c986669FEc",
+      "aggregatorSymbol": "SGD/USD"
     },
     {
-      "address": "0x8f3Cf7ad23Cd3CaDbD9735AFf958023239c6A063",
-      "symbol": "DAI"
+      "asset": "0x8f3Cf7ad23Cd3CaDbD9735AFf958023239c6A063",
+      "assetSymbol": "DAI",
+      "aggregator": "0x62439095489Eb5dE4572de632248682c09a05Ad4",
+      "aggregatorSymbol": "DAI/USD"
     },
     {
-      "address": "0xE111178A87A3BFf0c8d18DECBa5798827539Ae99",
-      "symbol":  "EURS"
+      "asset": "0xE111178A87A3BFf0c8d18DECBa5798827539Ae99",
+      "assetSymbol": "EURS",
+      "aggregator": "0x310990E8091b5cF083fA55F500F140CFBb959016",
+      "aggregatorSymbol": "EUR/USD"
     },
     {
-      "address": "0xE6A537a407488807F0bbeb0038B79004f19DDDFb",
-      "symbol":  "BRLA"
+      "asset": "0xE6A537a407488807F0bbeb0038B79004f19DDDFb",
+      "assetSymbol": "BRLA",
+      "aggregator": "0x6DBd1be1a83005d26b582D61937b406300B05A8F",
+      "aggregatorSymbol": "BRL/USD"
     },
     {
-      "address": "0xC8bB8eDa94931cA2F20EF43eA7dBD58E68400400",
-      "symbol":  "VNXAU"
-    }
-  ],
-  "fxAggregators": [
-    {
-      "address": "0xf9c53A834F60cBbE40E27702276fBc0819B3aFAD",
-      "symbol": "USDC-USD"
+      "asset": "0xC8bB8eDa94931cA2F20EF43eA7dBD58E68400400",
+      "assetSymbol": "VNXAU",
+      "aggregator": "0x704179beB09282EaEf98CA8aaa443C1E273eBBc2",
+      "aggregatorSymbol": "XAU/USD"
     },
     {
-      "address": "0x45ede0Ea5cBbE380C663C7C3015Cc7c986669FEc",
-      "symbol": "XSGD-USD"
+      "asset": "0xCdB3867935247049e87c38eA270edD305D84c9AE",
+      "assetSymbol": "VCHF",
+      "aggregator": "0x8123bEaCB5bca3AfA0C9ff71B28549d58cEc8176",
+      "aggregatorSymbol": "CHF/USD"
     },
     {
-      "address": "0x62439095489Eb5dE4572de632248682c09a05Ad4",
-      "symbol": "DAI-USD"
-    },
-    {
-      "address": "0x310990E8091b5cF083fA55F500F140CFBb959016",
-      "symbol": "EURS-USD"
-    },
-    {
-      "address": "0x6DBd1be1a83005d26b582D61937b406300B05A8F",
-      "symbol": "BRL-USD"
-    },
-    {
-      "address": "0x704179beB09282EaEf98CA8aaa443C1E273eBBc2",
-      "symbol": "XAU-USD"
+      "asset": "0xE4095d9372E68d108225c306A4491cacfB33B097",
+      "assetSymbol": "VEUR",
+      "aggregator": "0x310990E8091b5cF083fA55F500F140CFBb959016",
+      "aggregatorSymbol": "EUR/USD"
     }
   ]
 }

--- a/src/mappings/helpers/assets.ts
+++ b/src/mappings/helpers/assets.ts
@@ -7,8 +7,7 @@ import { Address } from '@graphprotocol/graph-ts';
 class Assets {
   public stableAssets: Address[];
   public pricingAssets: Address[];
-  public fxAssets: Address[];
-  public fxAggregators: Address[];
+  public fxAssetAggregators: Address[][];
 }
 
 export const USDC_ADDRESS = Address.fromString('0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48');
@@ -30,6 +29,10 @@ export const assets: Assets = {
     Address.fromString('0xae37D54Ae477268B9997d4161B96b8200755935c'), // bb-a-DAI-V2
     Address.fromString('0x82698aeCc9E28e9Bb27608Bd52cF57f704BD1B83'), // bb-a-USDC-V2
     Address.fromString('0x2F4eb100552ef93840d5aDC30560E5513DFfFACb'), // bb-a-USDT-V2
+    Address.fromString('0x6667c6fa9f2b3Fc1Cc8D85320b62703d938E4385'), // bb-a-DAI-V3
+    Address.fromString('0xcbFA4532D8B2ade2C261D3DD5ef2A2284f792692'), // bb-a-USDC-V3
+    Address.fromString('0xA1697F9Af0875B63DdC472d6EeBADa8C1fAB8568'), // bb-a-USDT-V3
+    Address.fromString('0xfeBb0bbf162E64fb9D0dfe186E517d84C395f016'), // bb-a-USD-V3
     Address.fromString('0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599'), // WBTC
     Address.fromString('0xba100000625a3754423978a60c9317c58a424e3D'), // BAL
     Address.fromString('0x9f8F72aA9304c8B593d555F12eF6589cC3A579A2'), // MKR
@@ -37,17 +40,24 @@ export const assets: Assets = {
     Address.fromString('0x5c6ee304399dbdb9c8ef030ab642b10820db8f56'), // B-80BAL-20WETH
     Address.fromString('0x7D1AfA7B718fb893dB30A3aBc0Cfc608AaCfeBB0'), // MATIC
     Address.fromString('0xA13a9247ea42D743238089903570127DdA72fE44'), // bb-a-USD
+    Address.fromString('0x60D604890feaa0b5460B28A424407c24fe89374a'), // bb-a-WETH-V3
   ],
-  fxAssets: [
-    Address.fromString('0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48'), // USDC
-    Address.fromString('0x70e8dE73cE538DA2bEEd35d14187F6959a8ecA96'), // XSGD
-    Address.fromString('0x6B175474E89094C44Da98b954EedeAC495271d0F'), // DAI
-    Address.fromString('0xdB25f211AB05b1c97D595516F45794528a807ad8'), // EURS
-  ],
-  fxAggregators: [
-    Address.fromString('0x789190466E21a8b78b8027866CBBDc151542A26C'), // USDC-USD
-    Address.fromString('0xc96129C796F03bb21AC947EfC5329CD1F560305B'), // XSGD-USD
-    Address.fromString('0xDEc0a100eaD1fAa37407f0Edc76033426CF90b82'), // DAI-USD
-    Address.fromString('0x02F878A94a1AE1B15705aCD65b5519A46fe3517e'), // EURS-USD
+  fxAssetAggregators: [
+    [
+      Address.fromString('0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48'), // USDC
+      Address.fromString('0x789190466E21a8b78b8027866CBBDc151542A26C'), // USDC/USD
+    ],
+    [
+      Address.fromString('0x70e8dE73cE538DA2bEEd35d14187F6959a8ecA96'), // XSGD
+      Address.fromString('0xc96129C796F03bb21AC947EfC5329CD1F560305B'), // SGD/USD
+    ],
+    [
+      Address.fromString('0x6B175474E89094C44Da98b954EedeAC495271d0F'), // DAI
+      Address.fromString('0xDEc0a100eaD1fAa37407f0Edc76033426CF90b82'), // DAI/USD
+    ],
+    [
+      Address.fromString('0xdB25f211AB05b1c97D595516F45794528a807ad8'), // EURS
+      Address.fromString('0x02F878A94a1AE1B15705aCD65b5519A46fe3517e'), // EUR/USD
+    ],
   ],
 };

--- a/src/mappings/helpers/constants.ts
+++ b/src/mappings/helpers/constants.ts
@@ -27,8 +27,7 @@ export let MAX_NEG_PRICE_CHANGE = BigDecimal.fromString('-0.5'); // -50%%
 export const MIN_POOL_LIQUIDITY = BigDecimal.fromString('2000');
 export const MIN_SWAP_VALUE_USD = BigDecimal.fromString('1');
 
-export let FX_AGGREGATOR_ADDRESSES = assets.fxAggregators;
-export let FX_TOKEN_ADDRESSES = assets.fxAssets;
+export let FX_ASSET_AGGREGATORS = assets.fxAssetAggregators;
 
 export let USD_STABLE_ASSETS = assets.stableAssets;
 export let PRICING_ASSETS = assets.stableAssets.concat(assets.pricingAssets);

--- a/src/mappings/helpers/misc.ts
+++ b/src/mappings/helpers/misc.ts
@@ -16,7 +16,7 @@ import {
 import { ERC20 } from '../../types/Vault/ERC20';
 import { WeightedPool } from '../../types/Vault/WeightedPool';
 import { Swap as SwapEvent, Vault } from '../../types/Vault/Vault';
-import { ONE_BD, SWAP_IN, SWAP_OUT, VAULT_ADDRESS, ZERO, ZERO_ADDRESS, ZERO_BD, FX_TOKEN_ADDRESSES } from './constants';
+import { ONE_BD, SWAP_IN, SWAP_OUT, VAULT_ADDRESS, ZERO, ZERO_ADDRESS, ZERO_BD } from './constants';
 import { PoolType, getPoolAddress, isComposableStablePool } from './pools';
 import { ComposableStablePool } from '../../types/ComposableStablePoolFactory/ComposableStablePool';
 import { valueInUSD } from '../pricing';
@@ -298,12 +298,6 @@ export function createToken(tokenAddress: Address): Token {
   if (!isPoolCall.reverted) {
     let poolId = isPoolCall.value;
     token.pool = poolId.toHexString();
-  }
-
-  // assign oracle decimals for FX tokens
-  let tokenIndex = FX_TOKEN_ADDRESSES.indexOf(tokenAddress);
-  if (tokenIndex >= 0) {
-    token.fxOracleDecimals = 8; // @TODO: get decimals on-chain
   }
 
   token.name = name;

--- a/src/mappings/poolFactory.ts
+++ b/src/mappings/poolFactory.ts
@@ -1,11 +1,4 @@
-import {
-  ZERO_BD,
-  ZERO,
-  FX_ASSET_AGGREGATORS,
-  VAULT_ADDRESS,
-  ZERO_ADDRESS,
-  ProtocolFeeType,
-} from './helpers/constants';
+import { ZERO_BD, ZERO, FX_ASSET_AGGREGATORS, VAULT_ADDRESS, ZERO_ADDRESS, ProtocolFeeType } from './helpers/constants';
 import {
   getPoolTokenManager,
   getPoolTokens,

--- a/src/mappings/poolFactory.ts
+++ b/src/mappings/poolFactory.ts
@@ -1,7 +1,7 @@
 import {
   ZERO_BD,
   ZERO,
-  FX_AGGREGATOR_ADDRESSES,
+  FX_ASSET_AGGREGATORS,
   VAULT_ADDRESS,
   ZERO_ADDRESS,
   ProtocolFeeType,
@@ -584,7 +584,7 @@ export function handleNewFXPool(event: ethereum.Event): void {
    * */
   let poolId = event.parameters[1].value.toBytes();
   let poolAddress = event.parameters[2].value.toAddress();
-  let swapFee = ZERO; // @todo: figure out how to get swap fee from FXPool
+  let swapFee = ZERO; // fee is calculated on every swap
 
   // Create a PoolCreated event from generic ethereum.Event
   const poolCreatedEvent = new PoolCreated(
@@ -612,10 +612,16 @@ export function handleNewFXPool(event: ethereum.Event): void {
 
   FXPoolTemplate.create(poolAddress);
 
-  // Create templates for every Offchain Aggregator
-  for (let i: i32 = 0; i < FX_AGGREGATOR_ADDRESSES.length; i++) {
-    OffchainAggregator.create(FX_AGGREGATOR_ADDRESSES[i]);
-  }
+  // Create templates for each token Offchain Aggregator
+  let tokensAddresses = changetype<Address[]>(tokens);
+  tokensAddresses.forEach((tokenAddress) => {
+    for (let i = 0; i < FX_ASSET_AGGREGATORS.length; i++) {
+      if (FX_ASSET_AGGREGATORS[i][0] == tokenAddress) {
+        OffchainAggregator.create(FX_ASSET_AGGREGATORS[i][1]);
+        break;
+      }
+    }
+  });
 }
 
 function findOrInitializeVault(): Balancer {


### PR DESCRIPTION
# Description

- ability to update `latestFXPrice` of multiple tokens on `AnswerUpdated` event
- a different approach for calculating `VNXAU`'s `latestFXPrice`
  - oracle is representing the price of gold in "troy ounce" unit, but VNXAU price is $ per gram of gold, thus a need to do a simple `price = answer / pricePerGram` adjustment
- combine fxAssets & fxAggregator const to a single 2 dimension array
  - this change let's us to do the first point

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Change is deployed and can be tested on https://thegraph.com/hosted-service/subgraph/xave-finance/balancer-v2-polygon using this query:

```
{
  tokens(where: {symbol_in: ["USDC", "EURS", "XSGD", "BRLA", "VNXAU", "VCHF", "VEUR"]}) {
    id
    symbol
    latestFXPrice
  }
}
```

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas

### Merges to `dev`
- [ ] I have checked that the graft base is not a pruned deployment
