### PR TITLE
add redeployed composable v5 to zkevm

### DIFF
--- a/manifest.template.yaml
+++ b/manifest.template.yaml
@@ -692,6 +692,39 @@ dataSources:
         - event: PoolCreated(indexed address)
           handler: handleNewComposableStablePoolV5
   {{/if}}
+  {{#if ComposableStablePoolV5FactoryV2}}
+  - kind: ethereum/contract
+    name: ComposableStablePoolV5FactoryV2
+    network: {{network}}
+    source:
+      address: '{{ComposableStablePoolV5FactoryV2.address}}'
+      abi: ComposableStablePoolV2Factory
+      startBlock: {{ComposableStablePoolV5FactoryV2.startBlock}}
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.5
+      language: wasm/assemblyscript
+      file: ./src/mappings/poolFactory.ts
+      entities:
+        - Balancer
+        - Pool
+      abis:
+        - name: Vault
+          file: ./abis/Vault.json
+        - name: ERC20
+          file: ./abis/ERC20.json
+        - name: WeightedPool
+          file: ./abis/WeightedPool.json
+        - name: ComposableStablePoolV2Factory
+          file: ./abis/ComposableStablePoolV2Factory.json
+        - name: ComposableStablePool
+          file: ./abis/ComposableStablePool.json
+        - name: StablePool
+          file: ./abis/StablePool.json
+      eventHandlers:
+        - event: PoolCreated(indexed address)
+          handler: handleNewComposableStablePoolV5
+  {{/if}}
   {{#if HighAmpComposableStablePoolFactory}}
   - kind: ethereum/contract
     name: HighAmpComposableStablePoolFactory

--- a/networks.yaml
+++ b/networks.yaml
@@ -721,6 +721,9 @@ polygon-zkevm:
   ComposableStablePoolV5Factory:
     address: "0x956CCab09898C0AF2aCa5e6C229c3aD4E93d9288"
     startBlock: 2157318
+  ComposableStablePoolV5FactoryV2:
+    address: "0x577e5993B9Cc480F07F98B5Ebd055604bd9071C4"
+    startBlock: 7248126
   AaveLinearPoolV5Factory:
     address: "0x4b7b369989e613ff2C65768B7Cf930cC927F901E"
     startBlock: 220075


### PR DESCRIPTION
# Description

ComposableV5 factory has been re-deployed to zkEVM - https://github.com/balancer/balancer-deployments/pull/98
## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas

### Merges to `dev`
- [x] I have checked that the graft base is not a pruned deployment
