### PR TITLE
promote dev to prod

### DIFF
--- a/manifest.template.yaml
+++ b/manifest.template.yaml
@@ -692,6 +692,39 @@ dataSources:
         - event: PoolCreated(indexed address)
           handler: handleNewComposableStablePoolV5
   {{/if}}
+  {{#if ComposableStablePoolV5FactoryV2}}
+  - kind: ethereum/contract
+    name: ComposableStablePoolV5FactoryV2
+    network: {{network}}
+    source:
+      address: '{{ComposableStablePoolV5FactoryV2.address}}'
+      abi: ComposableStablePoolV2Factory
+      startBlock: {{ComposableStablePoolV5FactoryV2.startBlock}}
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.5
+      language: wasm/assemblyscript
+      file: ./src/mappings/poolFactory.ts
+      entities:
+        - Balancer
+        - Pool
+      abis:
+        - name: Vault
+          file: ./abis/Vault.json
+        - name: ERC20
+          file: ./abis/ERC20.json
+        - name: WeightedPool
+          file: ./abis/WeightedPool.json
+        - name: ComposableStablePoolV2Factory
+          file: ./abis/ComposableStablePoolV2Factory.json
+        - name: ComposableStablePool
+          file: ./abis/ComposableStablePool.json
+        - name: StablePool
+          file: ./abis/StablePool.json
+      eventHandlers:
+        - event: PoolCreated(indexed address)
+          handler: handleNewComposableStablePoolV5
+  {{/if}}
   {{#if HighAmpComposableStablePoolFactory}}
   - kind: ethereum/contract
     name: HighAmpComposableStablePoolFactory

--- a/networks.yaml
+++ b/networks.yaml
@@ -721,6 +721,9 @@ polygon-zkevm:
   ComposableStablePoolV5Factory:
     address: "0x956CCab09898C0AF2aCa5e6C229c3aD4E93d9288"
     startBlock: 2157318
+  ComposableStablePoolV5FactoryV2:
+    address: "0x577e5993B9Cc480F07F98B5Ebd055604bd9071C4"
+    startBlock: 7248126
   AaveLinearPoolV5Factory:
     address: "0x4b7b369989e613ff2C65768B7Cf930cC927F901E"
     startBlock: 220075


### PR DESCRIPTION
# Description

- #529 

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

- [x] [ComposableV5 on zkEVM from 2 factories](https://api.studio.thegraph.com/query/24660/balancer-polygon-zk-v2-beta/version/latest/graphql?query=%7B%0A%09pools(%0A++++where:+%7B%0A++++++poolType:+%22ComposableStable%22%0A++++++poolTypeVersion:+5%0A++++%7D%0A++)+%7B%0A%09++id%0A++++factory%0A%09%7D%0A%7D%0A)

### `dev` -> `master`
- [x] I have [checked](https://balancer.github.io/balancer-subgraph-v2/status.html) that all beta deployments have synced
- [ ] ~I have [checked](https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-polygon-prune-v2-beta/graphql?query=%0A%7B%0A++balancers%28block%3A%7Bnumber%3A1%7D%29%7B%0A++++id%0A++%7D%0A%7D) that the earliest block in the polygon pruned deployment is [block, date/time](https://polygonscan.com/block/block)~
  - [ ] ~The earliest block is more than 24 hours old~
- [x] I have checked that core metrics are the same in the beta and production deployments

