### PR TITLE
deploy polygon unpruned to production

### DIFF
--- a/.github/workflows/graph-studio.yml
+++ b/.github/workflows/graph-studio.yml
@@ -5,131 +5,131 @@ on:
     branches: master
 
 jobs:
-  deploy-studio-mainnet:
-    runs-on: ubuntu-latest
-    environment: graph
-    steps:
-      - uses: actions/checkout@v2
-      - name: Install node
-        uses: actions/setup-node@v1
-        with:
-          node-version: 16
-      - name: Install
-        run: yarn --frozen-lockfile
-      - name: Assets
-        run: yarn generate-assets
-      - name: Codegen
-        run: yarn codegen
-      - name: Build
-        run: yarn build
-      - uses: gtaschuk/graph-deploy@v0.1.11
-        with:
-          graph_deploy_key: ${{secrets.GRAPH_DEPLOY_KEY}}
-          graph_version_label: ${GITHUB_SHA::8}
-          graph_subgraph_name: "balancer-v2"
-          graph_account: "balancer-labs"
-          graph_config_file: "subgraph.yaml"
-          graph_deploy_studio: true
-  deploy-studio-base-testnet:
-    runs-on: ubuntu-latest
-    environment: graph
-    steps:
-      - uses: actions/checkout@v2
-      - name: Install node
-        uses: actions/setup-node@v1
-        with:
-          node-version: 16
-      - name: Install
-        run: yarn --frozen-lockfile
-      - name: Assets
-        run: yarn generate-assets
-      - name: Codegen
-        run: yarn codegen
-      - name: Build
-        run: yarn build
-      - uses: gtaschuk/graph-deploy@v0.1.11
-        with:
-          graph_deploy_key: ${{secrets.GRAPH_DEPLOY_KEY}}
-          graph_version_label: ${GITHUB_SHA::8}
-          graph_subgraph_name: "balancer-base-testnet-v2"
-          graph_account: "balancer-labs"
-          graph_config_file: "subgraph.basegoerli.yaml"
-          graph_deploy_studio: true
-  deploy-studio-sepolia:
-    runs-on: ubuntu-latest
-    environment: graph
-    steps:
-      - uses: actions/checkout@v2
-      - name: Install node
-        uses: actions/setup-node@v1
-        with:
-          node-version: 16
-      - name: Install
-        run: yarn --frozen-lockfile
-      - name: Assets
-        run: yarn generate-assets sepolia
-      - name: Codegen
-        run: yarn codegen
-      - name: Build
-        run: yarn build
-      - uses: gtaschuk/graph-deploy@v0.1.11
-        with:
-          graph_deploy_key: ${{secrets.GRAPH_DEPLOY_KEY}}
-          graph_version_label: ${GITHUB_SHA::8}
-          graph_subgraph_name: "balancer-sepolia-v2"
-          graph_account: "balancer-labs"
-          graph_config_file: "subgraph.sepolia.yaml"
-          graph_deploy_studio: true
-  deploy-studio-polygon-zkevm:
-    runs-on: ubuntu-latest
-    environment: graph
-    steps:
-      - uses: actions/checkout@v2
-      - name: Install node
-        uses: actions/setup-node@v1
-        with:
-          node-version: 16
-      - name: Install
-        run: yarn --frozen-lockfile
-      - name: Assets
-        run: yarn generate-assets polygon-zkevm
-      - name: Codegen
-        run: yarn codegen
-      - name: Build
-        run: yarn build
-      - uses: gtaschuk/graph-deploy@v0.1.11
-        with:
-          graph_deploy_key: ${{secrets.GRAPH_DEPLOY_KEY}}
-          graph_version_label: ${GITHUB_SHA::8}
-          graph_subgraph_name: "balancer-polygon-zk-v2"
-          graph_account: "balancer-labs"
-          graph_config_file: "subgraph.polygon-zkevm.yaml"
-          graph_deploy_studio: true
-  deploy-studio-base:
-    runs-on: ubuntu-latest
-    environment: graph
-    steps:
-      - uses: actions/checkout@v2
-      - name: Install node
-        uses: actions/setup-node@v1
-        with:
-          node-version: 16
-      - name: Install
-        run: yarn --frozen-lockfile
-      - name: Assets
-        run: yarn generate-assets base
-      - name: Codegen
-        run: yarn codegen
-      - name: Build
-        run: yarn build
-      - uses: gtaschuk/graph-deploy@v0.1.11
-        with:
-          graph_deploy_key: ${{secrets.GRAPH_DEPLOY_KEY}}
-          graph_version_label: ${GITHUB_SHA::8}
-          graph_subgraph_name: "balancer-base-v2"
-          graph_account: "balancer-labs"
-          graph_config_file: "subgraph.base.yaml"
-          graph_deploy_studio: true
+  # deploy-studio-mainnet:
+  #   runs-on: ubuntu-latest
+  #   environment: graph
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - name: Install node
+  #       uses: actions/setup-node@v1
+  #       with:
+  #         node-version: 16
+  #     - name: Install
+  #       run: yarn --frozen-lockfile
+  #     - name: Assets
+  #       run: yarn generate-assets
+  #     - name: Codegen
+  #       run: yarn codegen
+  #     - name: Build
+  #       run: yarn build
+  #     - uses: gtaschuk/graph-deploy@v0.1.11
+  #       with:
+  #         graph_deploy_key: ${{secrets.GRAPH_DEPLOY_KEY}}
+  #         graph_version_label: ${GITHUB_SHA::8}
+  #         graph_subgraph_name: "balancer-v2"
+  #         graph_account: "balancer-labs"
+  #         graph_config_file: "subgraph.yaml"
+  #         graph_deploy_studio: true
+  # deploy-studio-base-testnet:
+  #   runs-on: ubuntu-latest
+  #   environment: graph
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - name: Install node
+  #       uses: actions/setup-node@v1
+  #       with:
+  #         node-version: 16
+  #     - name: Install
+  #       run: yarn --frozen-lockfile
+  #     - name: Assets
+  #       run: yarn generate-assets
+  #     - name: Codegen
+  #       run: yarn codegen
+  #     - name: Build
+  #       run: yarn build
+  #     - uses: gtaschuk/graph-deploy@v0.1.11
+  #       with:
+  #         graph_deploy_key: ${{secrets.GRAPH_DEPLOY_KEY}}
+  #         graph_version_label: ${GITHUB_SHA::8}
+  #         graph_subgraph_name: "balancer-base-testnet-v2"
+  #         graph_account: "balancer-labs"
+  #         graph_config_file: "subgraph.basegoerli.yaml"
+  #         graph_deploy_studio: true
+  # deploy-studio-sepolia:
+  #   runs-on: ubuntu-latest
+  #   environment: graph
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - name: Install node
+  #       uses: actions/setup-node@v1
+  #       with:
+  #         node-version: 16
+  #     - name: Install
+  #       run: yarn --frozen-lockfile
+  #     - name: Assets
+  #       run: yarn generate-assets sepolia
+  #     - name: Codegen
+  #       run: yarn codegen
+  #     - name: Build
+  #       run: yarn build
+  #     - uses: gtaschuk/graph-deploy@v0.1.11
+  #       with:
+  #         graph_deploy_key: ${{secrets.GRAPH_DEPLOY_KEY}}
+  #         graph_version_label: ${GITHUB_SHA::8}
+  #         graph_subgraph_name: "balancer-sepolia-v2"
+  #         graph_account: "balancer-labs"
+  #         graph_config_file: "subgraph.sepolia.yaml"
+  #         graph_deploy_studio: true
+  # deploy-studio-polygon-zkevm:
+  #   runs-on: ubuntu-latest
+  #   environment: graph
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - name: Install node
+  #       uses: actions/setup-node@v1
+  #       with:
+  #         node-version: 16
+  #     - name: Install
+  #       run: yarn --frozen-lockfile
+  #     - name: Assets
+  #       run: yarn generate-assets polygon-zkevm
+  #     - name: Codegen
+  #       run: yarn codegen
+  #     - name: Build
+  #       run: yarn build
+  #     - uses: gtaschuk/graph-deploy@v0.1.11
+  #       with:
+  #         graph_deploy_key: ${{secrets.GRAPH_DEPLOY_KEY}}
+  #         graph_version_label: ${GITHUB_SHA::8}
+  #         graph_subgraph_name: "balancer-polygon-zk-v2"
+  #         graph_account: "balancer-labs"
+  #         graph_config_file: "subgraph.polygon-zkevm.yaml"
+  #         graph_deploy_studio: true
+  # deploy-studio-base:
+  #   runs-on: ubuntu-latest
+  #   environment: graph
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - name: Install node
+  #       uses: actions/setup-node@v1
+  #       with:
+  #         node-version: 16
+  #     - name: Install
+  #       run: yarn --frozen-lockfile
+  #     - name: Assets
+  #       run: yarn generate-assets base
+  #     - name: Codegen
+  #       run: yarn codegen
+  #     - name: Build
+  #       run: yarn build
+  #     - uses: gtaschuk/graph-deploy@v0.1.11
+  #       with:
+  #         graph_deploy_key: ${{secrets.GRAPH_DEPLOY_KEY}}
+  #         graph_version_label: ${GITHUB_SHA::8}
+  #         graph_subgraph_name: "balancer-base-v2"
+  #         graph_account: "balancer-labs"
+  #         graph_config_file: "subgraph.base.yaml"
+  #         graph_deploy_studio: true
 
 env:
   CI: true

--- a/.github/workflows/graph.yml
+++ b/.github/workflows/graph.yml
@@ -5,52 +5,52 @@ on:
     branches: master
 
 jobs:
-  deploy-goerli:
-    runs-on: ubuntu-latest
-    environment: graph
-    steps:
-      - uses: actions/checkout@v2
-      - name: Install node
-        uses: actions/setup-node@v1
-        with:
-          node-version: 16
-      - name: Install
-        run: yarn --frozen-lockfile
-      - name: Assets
-        run: yarn generate-assets goerli
-      - name: Codegen
-        run: yarn codegen
-      - name: Build
-        run: yarn build
-      - uses: balancer-labs/graph-deploy@v0.0.1
-        with:
-          graph_access_token: ${{secrets.GRAPH_ACCESS_TOKEN}}
-          graph_subgraph_name: "balancer-goerli-v2"
-          graph_account: "balancer-labs"
-          graph_config_file: "subgraph.goerli.yaml"
-  deploy-mainnet:
-    runs-on: ubuntu-latest
-    environment: graph
-    steps:
-      - uses: actions/checkout@v2
-      - name: Install node
-        uses: actions/setup-node@v1
-        with:
-          node-version: 16
-      - name: Install
-        run: yarn --frozen-lockfile
-      - name: Assets
-        run: yarn generate-assets
-      - name: Codegen
-        run: yarn codegen
-      - name: Build
-        run: yarn build
-      - uses: balancer-labs/graph-deploy@v0.0.1
-        with:
-          graph_access_token: ${{secrets.GRAPH_ACCESS_TOKEN}}
-          graph_subgraph_name: "balancer-v2"
-          graph_account: "balancer-labs"
-          graph_config_file: "subgraph.yaml"
+  # deploy-goerli:
+  #   runs-on: ubuntu-latest
+  #   environment: graph
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - name: Install node
+  #       uses: actions/setup-node@v1
+  #       with:
+  #         node-version: 16
+  #     - name: Install
+  #       run: yarn --frozen-lockfile
+  #     - name: Assets
+  #       run: yarn generate-assets goerli
+  #     - name: Codegen
+  #       run: yarn codegen
+  #     - name: Build
+  #       run: yarn build
+  #     - uses: balancer-labs/graph-deploy@v0.0.1
+  #       with:
+  #         graph_access_token: ${{secrets.GRAPH_ACCESS_TOKEN}}
+  #         graph_subgraph_name: "balancer-goerli-v2"
+  #         graph_account: "balancer-labs"
+  #         graph_config_file: "subgraph.goerli.yaml"
+  # deploy-mainnet:
+  #   runs-on: ubuntu-latest
+  #   environment: graph
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - name: Install node
+  #       uses: actions/setup-node@v1
+  #       with:
+  #         node-version: 16
+  #     - name: Install
+  #       run: yarn --frozen-lockfile
+  #     - name: Assets
+  #       run: yarn generate-assets
+  #     - name: Codegen
+  #       run: yarn codegen
+  #     - name: Build
+  #       run: yarn build
+  #     - uses: balancer-labs/graph-deploy@v0.0.1
+  #       with:
+  #         graph_access_token: ${{secrets.GRAPH_ACCESS_TOKEN}}
+  #         graph_subgraph_name: "balancer-v2"
+  #         graph_account: "balancer-labs"
+  #         graph_config_file: "subgraph.yaml"
   deploy-polygon:
     runs-on: ubuntu-latest
     environment: graph
@@ -63,7 +63,7 @@ jobs:
       - name: Install
         run: yarn --frozen-lockfile
       - name: Assets
-        run: yarn generate-assets polygon-prune
+        run: yarn generate-assets polygon
       - name: Codegen
         run: yarn codegen
       - name: Build
@@ -73,145 +73,145 @@ jobs:
           graph_access_token: ${{secrets.GRAPH_ACCESS_TOKEN}}
           graph_subgraph_name: "balancer-polygon-v2"
           graph_account: "balancer-labs"
-          graph_config_file: "subgraph.polygon.pruned.yaml"
-  deploy-polygon-pruned:
-    runs-on: ubuntu-latest
-    environment: graph
-    steps:
-      - uses: actions/checkout@v2
-      - name: Install node
-        uses: actions/setup-node@v1
-        with:
-          node-version: 16
-      - name: Install
-        run: yarn --frozen-lockfile
-      - name: Assets
-        run: yarn generate-assets polygon-prune
-      - name: Codegen
-        run: yarn codegen
-      - name: Build
-        run: yarn build
-      - uses: balancer-labs/graph-deploy@v0.0.1
-        with:
-          graph_access_token: ${{secrets.GRAPH_ACCESS_TOKEN}}
-          graph_subgraph_name: "balancer-polygon-prune-v2"
-          graph_account: "balancer-labs"
-          graph_config_file: "subgraph.polygon.pruned.yaml"
-  deploy-arbitrum:
-    runs-on: ubuntu-latest
-    environment: graph
-    steps:
-      - uses: actions/checkout@v2
-      - name: Install node
-        uses: actions/setup-node@v1
-        with:
-          node-version: 16
-      - name: Install
-        run: yarn --frozen-lockfile
-      - name: Assets
-        run: yarn generate-assets arbitrum
-      - name: Codegen
-        run: yarn codegen
-      - name: Build
-        run: yarn build
-      - uses: balancer-labs/graph-deploy@v0.0.1
-        with:
-          graph_access_token: ${{secrets.GRAPH_ACCESS_TOKEN}}
-          graph_subgraph_name: "balancer-arbitrum-v2"
-          graph_account: "balancer-labs"
-          graph_config_file: "subgraph.arbitrum.yaml"
-  deploy-gnosis:
-    runs-on: ubuntu-latest
-    environment: graph
-    steps:
-      - uses: actions/checkout@v2
-      - name: Install node
-        uses: actions/setup-node@v1
-        with:
-          node-version: 16
-      - name: Install
-        run: yarn --frozen-lockfile
-      - name: Assets
-        run: yarn generate-assets gnosis
-      - name: Codegen
-        run: yarn codegen
-      - name: Build
-        run: yarn build
-      - uses: balancer-labs/graph-deploy@v0.0.1
-        with:
-          graph_access_token: ${{secrets.GRAPH_ACCESS_TOKEN}}
-          graph_subgraph_name: "balancer-gnosis-chain-v2"
-          graph_account: "balancer-labs"
-          graph_config_file: "subgraph.gnosis.yaml"
-  deploy-bnb:
-    runs-on: ubuntu-latest
-    environment: graph
-    steps:
-      - uses: actions/checkout@v2
-      - name: Install node
-        uses: actions/setup-node@v1
-        with:
-          node-version: 16
-      - name: Install
-        run: yarn --frozen-lockfile
-      - name: Assets
-        run: yarn generate-assets bnb
-      - name: Codegen
-        run: yarn codegen
-      - name: Build
-        run: yarn build
-      - uses: balancer-labs/graph-deploy@v0.0.1
-        with:
-          graph_access_token: ${{secrets.GRAPH_ACCESS_TOKEN}}
-          graph_subgraph_name: "balancer-bnbchain-v2"
-          graph_account: "balancer-labs"
-          graph_config_file: "subgraph.bnb.yaml"
-  deploy-avalanche:
-    runs-on: ubuntu-latest
-    environment: graph
-    steps:
-      - uses: actions/checkout@v2
-      - name: Install node
-        uses: actions/setup-node@v1
-        with:
-          node-version: 16
-      - name: Install
-        run: yarn --frozen-lockfile
-      - name: Assets
-        run: yarn generate-assets avalanche
-      - name: Codegen
-        run: yarn codegen
-      - name: Build
-        run: yarn build
-      - uses: balancer-labs/graph-deploy@v0.0.1
-        with:
-          graph_access_token: ${{secrets.GRAPH_ACCESS_TOKEN}}
-          graph_subgraph_name: "balancer-avalanche-v2"
-          graph_account: "balancer-labs"
-          graph_config_file: "subgraph.avalanche.yaml"
-  deploy-optimism:
-    runs-on: ubuntu-latest
-    environment: graph
-    steps:
-      - uses: actions/checkout@v2
-      - name: Install node
-        uses: actions/setup-node@v1
-        with:
-          node-version: 16
-      - name: Install
-        run: yarn --frozen-lockfile
-      - name: Assets
-        run: yarn generate-assets optimism
-      - name: Codegen
-        run: yarn codegen
-      - name: Build
-        run: yarn build
-      - uses: balancer-labs/graph-deploy@v0.0.1
-        with:
-          graph_access_token: ${{secrets.GRAPH_ACCESS_TOKEN}}
-          graph_subgraph_name: "balancer-optimism-v2"
-          graph_account: "balancer-labs"
-          graph_config_file: "subgraph.optimism.yaml"
+          graph_config_file: "subgraph.polygon.yaml"
+  # deploy-polygon-pruned:
+  #   runs-on: ubuntu-latest
+  #   environment: graph
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - name: Install node
+  #       uses: actions/setup-node@v1
+  #       with:
+  #         node-version: 16
+  #     - name: Install
+  #       run: yarn --frozen-lockfile
+  #     - name: Assets
+  #       run: yarn generate-assets polygon-prune
+  #     - name: Codegen
+  #       run: yarn codegen
+  #     - name: Build
+  #       run: yarn build
+  #     - uses: balancer-labs/graph-deploy@v0.0.1
+  #       with:
+  #         graph_access_token: ${{secrets.GRAPH_ACCESS_TOKEN}}
+  #         graph_subgraph_name: "balancer-polygon-prune-v2"
+  #         graph_account: "balancer-labs"
+  #         graph_config_file: "subgraph.polygon.pruned.yaml"
+  # deploy-arbitrum:
+  #   runs-on: ubuntu-latest
+  #   environment: graph
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - name: Install node
+  #       uses: actions/setup-node@v1
+  #       with:
+  #         node-version: 16
+  #     - name: Install
+  #       run: yarn --frozen-lockfile
+  #     - name: Assets
+  #       run: yarn generate-assets arbitrum
+  #     - name: Codegen
+  #       run: yarn codegen
+  #     - name: Build
+  #       run: yarn build
+  #     - uses: balancer-labs/graph-deploy@v0.0.1
+  #       with:
+  #         graph_access_token: ${{secrets.GRAPH_ACCESS_TOKEN}}
+  #         graph_subgraph_name: "balancer-arbitrum-v2"
+  #         graph_account: "balancer-labs"
+  #         graph_config_file: "subgraph.arbitrum.yaml"
+  # deploy-gnosis:
+  #   runs-on: ubuntu-latest
+  #   environment: graph
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - name: Install node
+  #       uses: actions/setup-node@v1
+  #       with:
+  #         node-version: 16
+  #     - name: Install
+  #       run: yarn --frozen-lockfile
+  #     - name: Assets
+  #       run: yarn generate-assets gnosis
+  #     - name: Codegen
+  #       run: yarn codegen
+  #     - name: Build
+  #       run: yarn build
+  #     - uses: balancer-labs/graph-deploy@v0.0.1
+  #       with:
+  #         graph_access_token: ${{secrets.GRAPH_ACCESS_TOKEN}}
+  #         graph_subgraph_name: "balancer-gnosis-chain-v2"
+  #         graph_account: "balancer-labs"
+  #         graph_config_file: "subgraph.gnosis.yaml"
+  # deploy-bnb:
+  #   runs-on: ubuntu-latest
+  #   environment: graph
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - name: Install node
+  #       uses: actions/setup-node@v1
+  #       with:
+  #         node-version: 16
+  #     - name: Install
+  #       run: yarn --frozen-lockfile
+  #     - name: Assets
+  #       run: yarn generate-assets bnb
+  #     - name: Codegen
+  #       run: yarn codegen
+  #     - name: Build
+  #       run: yarn build
+  #     - uses: balancer-labs/graph-deploy@v0.0.1
+  #       with:
+  #         graph_access_token: ${{secrets.GRAPH_ACCESS_TOKEN}}
+  #         graph_subgraph_name: "balancer-bnbchain-v2"
+  #         graph_account: "balancer-labs"
+  #         graph_config_file: "subgraph.bnb.yaml"
+  # deploy-avalanche:
+  #   runs-on: ubuntu-latest
+  #   environment: graph
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - name: Install node
+  #       uses: actions/setup-node@v1
+  #       with:
+  #         node-version: 16
+  #     - name: Install
+  #       run: yarn --frozen-lockfile
+  #     - name: Assets
+  #       run: yarn generate-assets avalanche
+  #     - name: Codegen
+  #       run: yarn codegen
+  #     - name: Build
+  #       run: yarn build
+  #     - uses: balancer-labs/graph-deploy@v0.0.1
+  #       with:
+  #         graph_access_token: ${{secrets.GRAPH_ACCESS_TOKEN}}
+  #         graph_subgraph_name: "balancer-avalanche-v2"
+  #         graph_account: "balancer-labs"
+  #         graph_config_file: "subgraph.avalanche.yaml"
+  # deploy-optimism:
+  #   runs-on: ubuntu-latest
+  #   environment: graph
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - name: Install node
+  #       uses: actions/setup-node@v1
+  #       with:
+  #         node-version: 16
+  #     - name: Install
+  #       run: yarn --frozen-lockfile
+  #     - name: Assets
+  #       run: yarn generate-assets optimism
+  #     - name: Codegen
+  #       run: yarn codegen
+  #     - name: Build
+  #       run: yarn build
+  #     - uses: balancer-labs/graph-deploy@v0.0.1
+  #       with:
+  #         graph_access_token: ${{secrets.GRAPH_ACCESS_TOKEN}}
+  #         graph_subgraph_name: "balancer-optimism-v2"
+  #         graph_account: "balancer-labs"
+  #         graph_config_file: "subgraph.optimism.yaml"
 
 env:
   CI: true


### PR DESCRIPTION
# Description

I'm editing the GH Action to only promote Polygon to Prod in order to revert https://github.com/balancer/balancer-subgraph-v2/pull/534/commits/e7087abaeeb49720641124d98ce1e112f5dac9c2

Note there's an updates on staging we could promote but that hasn't been tested yet - we're waiting Gyro's team to deploy pools. I opted to branch off `master` and edit the GH actions instead of doing that on `dev` - that would take #425 to `master` and I didn't want to have a code on production that doesn't represent what's currently deployed to it.
