### PR TITLE
Refactoring update pool weights

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -59,6 +59,7 @@ type Pool @entity {
   historicalValues: [PoolHistoricalLiquidity!] @derivedFrom(field: "poolId")
 
   # LiquidityBootstrappingPool Only
+  latestWeightUpdate: GradualWeightUpdate
   weightUpdates: [GradualWeightUpdate!] @derivedFrom(field: "poolId")
 
   # StablePool Only

--- a/src/mappings/helpers/weighted.ts
+++ b/src/mappings/helpers/weighted.ts
@@ -95,6 +95,6 @@ export function updatePoolWeights(poolId: string, blockTimestamp: BigInt): void 
       }
       pool.totalWeight = totalWeight;
     }
-    pool.save();
   }
+  pool.save();
 }

--- a/src/mappings/helpers/weighted.ts
+++ b/src/mappings/helpers/weighted.ts
@@ -31,9 +31,9 @@ class GradualValueChange {
 
   public getInterpolateValue(
     startValue: BigInt,
-    endValue: BigInt, 
-    startTimestamp: BigInt, 
-    endTimestamp: BigInt, 
+    endValue: BigInt,
+    startTimestamp: BigInt,
+    endTimestamp: BigInt,
     blockTimestamp: BigInt
   ): BigInt {
     let pctProgress: BigInt = this.calculateValueChangeProgress(startTimestamp, endTimestamp, blockTimestamp);
@@ -44,7 +44,6 @@ class GradualValueChange {
 const Calc = new GradualValueChange();
 
 export function updatePoolWeights(poolId: string, blockTimestamp: BigInt): void {
-
   let pool = Pool.load(poolId);
   if (pool == null) return;
 
@@ -62,12 +61,13 @@ export function updatePoolWeights(poolId: string, blockTimestamp: BigInt): void 
   // let tokensList = pool.tokensList;
 
   let latestWeightUpdateId = pool.latestWeightUpdate;
+  
   if (latestWeightUpdateId === null) {
       return;
   } else {
     // Load in the last GradualWeightUpdateScheduled event information
     let latestUpdate = GradualWeightUpdate.load(latestWeightUpdateId) as GradualWeightUpdate;
-  
+    
     let startWeights: BigInt[] = latestUpdate.startWeights;
     let endWeights: BigInt[] = latestUpdate.endWeights;
     let startTimestamp: BigInt = latestUpdate.startTimestamp;
@@ -79,9 +79,15 @@ export function updatePoolWeights(poolId: string, blockTimestamp: BigInt): void 
 
       for (let i = 0; i < tokensList.length; i++) {
         let tokenAddress = changetype<Address>(tokensList[i]);
-
-        let weight = Calc.getInterpolateValue(startWeights[i], endWeights[i], startTimestamp, endTimestamp, blockTimestamp);
-
+ 
+        let weight = Calc.getInterpolateValue(
+          startWeights[i],
+          endWeights[i],
+          startTimestamp,
+          endTimestamp,
+          blockTimestamp
+        );
+  
         let poolToken = loadPoolToken(poolId, tokenAddress);
         if (poolToken != null) {
           poolToken.weight = scaleDown(weight, 18);

--- a/src/mappings/helpers/weighted.ts
+++ b/src/mappings/helpers/weighted.ts
@@ -19,7 +19,11 @@ class GradualValueChange {
   }
 
   private interpolateValue(startValue: BigInt, endValue: BigInt, pctProgress: BigInt): BigInt {
-    if (startValue.gt(endValue)) {
+    if (pctProgress.ge(ONE) || startValue == endValue) {
+      return endValue;
+    } else if (pctProgress == ZERO) {
+      return startValue;
+    } else if (startValue.gt(endValue)) {
       let delta: BigInt = pctProgress.times(startValue.minus(endValue));
       return startValue.minus(delta);
     } else {

--- a/src/mappings/helpers/weighted.ts
+++ b/src/mappings/helpers/weighted.ts
@@ -35,7 +35,7 @@ export function updatePoolWeights(poolId: string, blockTimestamp: BigInt): void 
           poolToken.weight = scaleDown(weight, 18);
           poolToken.save();
         }
-        totalWeight = totalWeight.plus(scaleDown(weight, 18));
+        totalWeight = totalWeight + scaleDown(weight, 18);
       }
       pool.totalWeight = totalWeight;
     }
@@ -56,7 +56,7 @@ export function updatePoolWeights(poolId: string, blockTimestamp: BigInt): void 
           poolToken.weight = weight;
           poolToken.save();
         }
-        totalWeight = totalWeight.plus(weight);
+        totalWeight = totalWeight + weight;
       }
       pool.totalWeight = totalWeight;
     }
@@ -73,16 +73,16 @@ function calculateCurrentWeight(
 ): BigDecimal {
   const scalar: BigDecimal = BigDecimal.fromString('1000000000000000000');
 
-  if (blockTimestamp.ge(endTimestamp) || startWeight == endWeight) {
+  if (blockTimestamp >= endTimestamp || startWeight == endWeight) {
     return endWeight.toBigDecimal() / scalar;
-  } else if (blockTimestamp.le(startTimestamp)) {
+  } else if (blockTimestamp <= startTimestamp) {
     return startWeight.toBigDecimal() / scalar;
   } else {
-    const duration: BigInt = endTimestamp.minus(startTimestamp);
-    const elapsedTime: BigInt = blockTimestamp.minus(startTimestamp);
+    const duration: BigInt = endTimestamp - startTimestamp;
+    const elapsedTime: BigInt = blockTimestamp - startTimestamp;
     const pctProgress: BigDecimal = elapsedTime.toBigDecimal() / duration.toBigDecimal();
 
-    if (startWeight.gt(endWeight)) {
+    if (startWeight > endWeight) {
       let delta = pctProgress * (startWeight - endWeight).toBigDecimal();
       return (startWeight.toBigDecimal() - delta) / scalar;
     } else {

--- a/src/mappings/helpers/weighted.ts
+++ b/src/mappings/helpers/weighted.ts
@@ -21,7 +21,7 @@ export function updatePoolWeights(poolId: string, blockTimestamp: BigInt): void 
 
   let latestWeightUpdateId = pool.latestWeightUpdate;
   let weights: BigInt[] = [];
-  let latestUpdate = null;
+  let latestUpdate: any = "anything";
 
   if (latestWeightUpdateId === null) {
     let poolContract = WeightedPool.bind(changetype<Address>(pool.address));

--- a/src/mappings/helpers/weighted.ts
+++ b/src/mappings/helpers/weighted.ts
@@ -29,7 +29,13 @@ class GradualValueChange {
     }
   }
 
-  public getInterpolateValue(startValue: BigInt, endValue: BigInt, startTimestamp: BigInt, endTimestamp: BigInt, blockTimestamp: BigInt): BigInt {
+  public getInterpolateValue(
+    startValue: BigInt,
+    endValue: BigInt, 
+    startTimestamp: BigInt, 
+    endTimestamp: BigInt, 
+    blockTimestamp: BigInt
+  ): BigInt {
     let pctProgress: BigInt = this.calculateValueChangeProgress(startTimestamp, endTimestamp, blockTimestamp);
     return this.interpolateValue(startValue, endValue, pctProgress);
   }

--- a/src/mappings/helpers/weighted.ts
+++ b/src/mappings/helpers/weighted.ts
@@ -1,51 +1,9 @@
-import { Address, BigInt, Bytes, log } from '@graphprotocol/graph-ts';
+import { Address, BigInt, Bytes } from '@graphprotocol/graph-ts';
 
 import { Pool, GradualWeightUpdate } from '../../types/schema';
 
 import { ZERO_BD, ONE, ZERO } from './constants';
 import { scaleDown, loadPoolToken } from './misc';
-
-class GradualValueChange {
-  private calculateValueChangeProgress(startTimestamp: BigInt, endTimestamp: BigInt, blockTimestamp: BigInt): BigInt {
-    if (blockTimestamp.ge(endTimestamp)) {
-      return ONE;
-    } else if (blockTimestamp.le(startTimestamp)) {
-      return ZERO;
-    } else {
-      let totalSeconds: BigInt = endTimestamp.minus(startTimestamp);
-      let secondsElapsed: BigInt = blockTimestamp.minus(startTimestamp);
-      return secondsElapsed.div(totalSeconds);
-    }
-  }
-
-  private interpolateValue(startValue: BigInt, endValue: BigInt, pctProgress: BigInt): BigInt {
-    if (pctProgress.ge(ONE) || startValue == endValue) {
-      return endValue;
-    } else if (pctProgress == ZERO) {
-      return startValue;
-    } else if (startValue.gt(endValue)) {
-      let delta: BigInt = pctProgress.times(startValue.minus(endValue));
-      return startValue.minus(delta);
-    } else {
-      let delta: BigInt = pctProgress.times(endValue.minus(startValue));
-      return startValue.plus(delta);
-    }
-  }
-
-  public getInterpolateValue(
-    startValue: BigInt,
-    endValue: BigInt,
-    startTimestamp: BigInt,
-    endTimestamp: BigInt,
-    blockTimestamp: BigInt
-  ): BigInt {
-    let pctProgress: BigInt = this.calculateValueChangeProgress(startTimestamp, endTimestamp, blockTimestamp);
-    let currentWeight: BigInt = this.interpolateValue(startValue, endValue, pctProgress);
-    return currentWeight;
-  }
-}
-
-const Calc = new GradualValueChange();
 
 export function updatePoolWeights(poolId: string, blockTimestamp: BigInt): void {
   let pool = Pool.load(poolId);
@@ -60,47 +18,71 @@ export function updatePoolWeights(poolId: string, blockTimestamp: BigInt): void 
     }
   }
 
-  // let tokensList = pool.tokensList;
-
   let latestWeightUpdateId = pool.latestWeightUpdate;
-  if (latestWeightUpdateId === null) {
-    return;
-  } else {
-    // Load in the last GradualWeightUpdateScheduled event information
-    let latestUpdate = GradualWeightUpdate.load(latestWeightUpdateId) as GradualWeightUpdate;
+  let weights: BigInt[] = []
+  if (!latestWeightUpdateId) {
+    let poolContract = WeightedPool.bind(changetype<Address>(pool.address));
+    let weightsCall = poolContract.try_getNormalizedWeights();
+    weights = weightsCall.value;
+  }
+  let latestUpdate = GradualWeightUpdate.load(latestWeightUpdateId) as GradualWeightUpdate;
 
-    let startWeights: BigInt[] = latestUpdate.startWeights;
-    let endWeights: BigInt[] = latestUpdate.endWeights;
-    let startTimestamp: BigInt = latestUpdate.startTimestamp;
-    let endTimestamp: BigInt = latestUpdate.endTimestamp;
-    //let x: string = "In else statement";
-    //log.warning('Current info: (start: {}), (end: {}), (blocktime: {})', [startTimestamp.toString(), endTimestamp.toString(), blockTimestamp.toString()]);
-    //log.warning('X: {}', [x])
+  if (latestUpdate.startWeights.length == tokensList.length || weights.length == tokensList.length) {
+    let totalWeight = ZERO_BD;
 
-    if (startWeights.length == tokensList.length) {
-      let totalWeight = ZERO_BD;
-      //log.warning('Passed into second if statement: {} {}', [changetype<string>(startWeights.length), changetype<string>(tokensList.length)]);
-
-      for (let i = 0; i < tokensList.length; i++) {
-        let tokenAddress = changetype<Address>(tokensList[i]);
-        let weight = Calc.getInterpolateValue(
-          startWeights[i],
-          endWeights[i],
-          startTimestamp,
-          endTimestamp,
+    for (let i = 0; i < tokensList.length; i++) {
+      let tokenAddress = changetype<Address>(tokensList[i]);
+      if (!latestWeightUpdateId) {
+        let weight = scaleDown(weights[i], 18);
+      } else {
+        let weight = calculateCurrentWeight(
+          latestUpdate.startWeights[i],
+          latestUpdate.endWeights[i],
+          latestUpdate.startTimestamp,
+          latestUpdate.endTimestamp,
           blockTimestamp
         );
-
-        let poolToken = loadPoolToken(poolId, tokenAddress);
-        if (poolToken != null) {
-          poolToken.weight = scaleDown(weight, 18);
-          poolToken.save();
-          //log.debug('Token weight has been saved: {}', [changetype<string>(weight)])
-        }
-        totalWeight = totalWeight.plus(scaleDown(weight, 18));
       }
-      pool.totalWeight = totalWeight;
+
+      let poolToken = loadPoolToken(poolId, tokenAddress);
+      if (poolToken != null) {
+        poolToken.weight = weight;
+        poolToken.save();
+      }
+      totalWeight = totalWeight.plus(weight);
     }
+    pool.totalWeight = totalWeight;
   }
   pool.save();
+}
+
+function calculateCurrentWeight(
+  startWeight: BigInt,
+  endWeight: BigInt,
+  startTimestamp: BigInt,
+  endTimestamp: BigInt,
+  blockTimestamp: BigInt
+): BigInt {
+  let pctProgress: BigInt = ZERO;
+  let delta: BigInt = ZERO;
+  let currentWeight: BigInt = ZERO;
+
+  if (blockTimestamp.ge(endTimestamp) || startWeight == endWeight) {
+    currentWeight = endWeight;
+  } else if (blockTimestamp.le(startTimestamp)) {
+    currentWeight = startWeight;
+  } else {
+    const totalSeconds: BigInt = endTimestamp.minus(startTimestamp);
+    const secondsElapsed: BigInt = blockTimestamp.minus(startTimestamp);
+    pctProgress = secondsElapsed.div(totalSeconds);
+    if (startWeight.gt(endWeight)) {
+    delta = pctProgress.times(startWeight.minus(endWeight));
+    currentWeight = startWeight.minus(delta);
+    } else {
+    delta = pctProgress.times(endWeight.minus(startWeight));
+    currentWeight = startWeight.plus(delta);
+    }
+  }
+  currentWeight = scaleDown(currentWeight, 18);
+  return currentWeight;
 }

--- a/src/mappings/helpers/weighted.ts
+++ b/src/mappings/helpers/weighted.ts
@@ -60,8 +60,8 @@ export function updatePoolWeights(poolId: string, blockTimestamp: BigInt): void 
       return;
   } else {
     // Load in the last GradualWeightUpdateScheduled event information
-    let latestUpdate = GradualWeightUpdate.load(latestWeightUpdateId);
-
+    let latestUpdate = GradualWeightUpdate.load(latestWeightUpdateId) as GradualWeightUpdate;
+  
     let startWeights: BigInt[] = latestUpdate.startWeights;
     let endWeights: BigInt[] = latestUpdate.endWeights;
     let startTimestamp: BigInt = latestUpdate.startTimestamp;

--- a/src/mappings/helpers/weighted.ts
+++ b/src/mappings/helpers/weighted.ts
@@ -48,10 +48,10 @@ export function updatePoolWeights(poolId: string, blockTimestamp: BigInt): void 
 
       let poolToken = loadPoolToken(poolId, tokenAddress);
       if (poolToken != null) {
-        poolToken.weight = weight;
+        poolToken.weight = scaleDown(weight, 18);
         poolToken.save();
       }
-      totalWeight = totalWeight.plus(weight);
+      totalWeight = totalWeight.plus(scaleDown(weight, 18));
     }
     pool.totalWeight = totalWeight;
   }
@@ -67,24 +67,21 @@ function calculateCurrentWeight(
 ): BigInt {
   let pctProgress: BigInt = ZERO;
   let delta: BigInt = ZERO;
-  let currentWeight: BigInt = ZERO;
 
   if (blockTimestamp.ge(endTimestamp) || startWeight == endWeight) {
-    currentWeight = endWeight;
+    return endWeight;
   } else if (blockTimestamp.le(startTimestamp)) {
-    currentWeight = startWeight;
+    return startWeight;
   } else {
     const totalSeconds: BigInt = endTimestamp.minus(startTimestamp);
     const secondsElapsed: BigInt = blockTimestamp.minus(startTimestamp);
     pctProgress = secondsElapsed.div(totalSeconds);
     if (startWeight.gt(endWeight)) {
       delta = pctProgress.times(startWeight.minus(endWeight));
-      currentWeight = startWeight.minus(delta);
+      return startWeight.minus(delta);
     } else {
       delta = pctProgress.times(endWeight.minus(startWeight));
-      currentWeight = startWeight.plus(delta);
+      return startWeight.plus(delta);
     }
   }
-  currentWeight = scaleDown(currentWeight, 18);
-  return currentWeight;
 }

--- a/src/mappings/helpers/weighted.ts
+++ b/src/mappings/helpers/weighted.ts
@@ -35,7 +35,7 @@ export function updatePoolWeights(poolId: string, blockTimestamp: BigInt): void 
       let tokenAddress = changetype<Address>(tokensList[i]);
       let weight = ZERO;
       if (!latestWeightUpdateId) {
-        weight = scaleDown(weights[i], 18);
+        weight = weights[i];
       } else {
         weight = calculateCurrentWeight(
           latestUpdate.startWeights[i],

--- a/src/mappings/helpers/weighted.ts
+++ b/src/mappings/helpers/weighted.ts
@@ -1,4 +1,4 @@
-import { Address, BigInt, Bytes } from '@graphprotocol/graph-ts';
+import { Address, BigInt, Bytes, log } from '@graphprotocol/graph-ts';
 
 import { Pool, GradualWeightUpdate } from '../../types/schema';
 
@@ -40,7 +40,8 @@ class GradualValueChange {
     blockTimestamp: BigInt
   ): BigInt {
     let pctProgress: BigInt = this.calculateValueChangeProgress(startTimestamp, endTimestamp, blockTimestamp);
-    return this.interpolateValue(startValue, endValue, pctProgress);
+    let currentWeight: BigInt = this.interpolateValue(startValue, endValue, pctProgress);
+    return currentWeight;
   }
 }
 
@@ -72,9 +73,13 @@ export function updatePoolWeights(poolId: string, blockTimestamp: BigInt): void 
     let endWeights: BigInt[] = latestUpdate.endWeights;
     let startTimestamp: BigInt = latestUpdate.startTimestamp;
     let endTimestamp: BigInt = latestUpdate.endTimestamp;
+    //let x: string = "In else statement";
+    //log.warning('Current info: (start: {}), (end: {}), (blocktime: {})', [startTimestamp.toString(), endTimestamp.toString(), blockTimestamp.toString()]);
+    //log.warning('X: {}', [x])
 
     if (startWeights.length == tokensList.length) {
       let totalWeight = ZERO_BD;
+      //log.warning('Passed into second if statement: {} {}', [changetype<string>(startWeights.length), changetype<string>(tokensList.length)]);
 
       for (let i = 0; i < tokensList.length; i++) {
         let tokenAddress = changetype<Address>(tokensList[i]);
@@ -90,6 +95,7 @@ export function updatePoolWeights(poolId: string, blockTimestamp: BigInt): void 
         if (poolToken != null) {
           poolToken.weight = scaleDown(weight, 18);
           poolToken.save();
+          //log.debug('Token weight has been saved: {}', [changetype<string>(weight)])
         }
         totalWeight = totalWeight.plus(scaleDown(weight, 18));
       }

--- a/src/mappings/helpers/weighted.ts
+++ b/src/mappings/helpers/weighted.ts
@@ -61,25 +61,22 @@ export function updatePoolWeights(poolId: string, blockTimestamp: BigInt): void 
   // let tokensList = pool.tokensList;
 
   let latestWeightUpdateId = pool.latestWeightUpdate;
-  
   if (latestWeightUpdateId === null) {
       return;
   } else {
     // Load in the last GradualWeightUpdateScheduled event information
     let latestUpdate = GradualWeightUpdate.load(latestWeightUpdateId) as GradualWeightUpdate;
-    
+
     let startWeights: BigInt[] = latestUpdate.startWeights;
     let endWeights: BigInt[] = latestUpdate.endWeights;
     let startTimestamp: BigInt = latestUpdate.startTimestamp;
     let endTimestamp: BigInt = latestUpdate.endTimestamp;
 
     if (startWeights.length == tokensList.length) {
-
       let totalWeight = ZERO_BD;
 
       for (let i = 0; i < tokensList.length; i++) {
         let tokenAddress = changetype<Address>(tokensList[i]);
- 
         let weight = Calc.getInterpolateValue(
           startWeights[i],
           endWeights[i],
@@ -87,7 +84,7 @@ export function updatePoolWeights(poolId: string, blockTimestamp: BigInt): void 
           endTimestamp,
           blockTimestamp
         );
-  
+
         let poolToken = loadPoolToken(poolId, tokenAddress);
         if (poolToken != null) {
           poolToken.weight = scaleDown(weight, 18);

--- a/src/mappings/helpers/weighted.ts
+++ b/src/mappings/helpers/weighted.ts
@@ -29,8 +29,7 @@ export function updatePoolWeights(poolId: string, blockTimestamp: BigInt): void 
     if (weights.length == tokensList.length) {
       for (let i = 0; i < tokensList.length; i++) {
         let tokenAddress = changetype<Address>(tokensList[i]);
-        let weight = ZERO;
-        weight = weights[i];
+        let weight = weights[i];
         let poolToken = loadPoolToken(poolId, tokenAddress);
         if (poolToken != null) {
           poolToken.weight = scaleDown(weight, 18);
@@ -45,7 +44,7 @@ export function updatePoolWeights(poolId: string, blockTimestamp: BigInt): void 
     if (latestUpdate.startWeights.length == tokensList.length) {
       for (let i = 0; i < tokensList.length; i++) {
         let tokenAddress = changetype<Address>(tokensList[i]);
-        weight = calculateCurrentWeight(
+        let weight = calculateCurrentWeight(
           latestUpdate.startWeights[i],
           latestUpdate.endWeights[i],
           latestUpdate.startTimestamp,

--- a/src/mappings/helpers/weighted.ts
+++ b/src/mappings/helpers/weighted.ts
@@ -21,7 +21,7 @@ export function updatePoolWeights(poolId: string, blockTimestamp: BigInt): void 
 
   let latestWeightUpdateId = pool.latestWeightUpdate;
   let weights: BigInt[] = [];
-  let latestUpdate: any = "anything";
+  let latestUpdate: any = 'anything';
 
   if (latestWeightUpdateId === null) {
     let poolContract = WeightedPool.bind(changetype<Address>(pool.address));

--- a/src/mappings/helpers/weighted.ts
+++ b/src/mappings/helpers/weighted.ts
@@ -21,11 +21,11 @@ class GradualValueChange {
 
   private interpolateValue(startValue: BigInt, endValue: BigInt, pctProgress: BigInt): BigInt {
     if (startValue.gt(endValue)) {
-        let delta: BigInt = pctProgress.times(startValue.minus(endValue));
-        return startValue.minus(delta);
+      let delta: BigInt = pctProgress.times(startValue.minus(endValue));
+      return startValue.minus(delta);
     } else {
-        let delta: BigInt = pctProgress.times(endValue.minus(startValue));
-        return startValue.plus(delta);
+      let delta: BigInt = pctProgress.times(endValue.minus(startValue));
+      return startValue.plus(delta);
     }
   }
 
@@ -62,7 +62,7 @@ export function updatePoolWeights(poolId: string, blockTimestamp: BigInt): void 
 
   let latestWeightUpdateId = pool.latestWeightUpdate;
   if (latestWeightUpdateId === null) {
-      return;
+    return;
   } else {
     // Load in the last GradualWeightUpdateScheduled event information
     let latestUpdate = GradualWeightUpdate.load(latestWeightUpdateId) as GradualWeightUpdate;

--- a/src/mappings/helpers/weighted.ts
+++ b/src/mappings/helpers/weighted.ts
@@ -35,7 +35,7 @@ export function updatePoolWeights(poolId: string, blockTimestamp: BigInt): void 
           poolToken.weight = scaleDown(weight, 18);
           poolToken.save();
         }
-        totalWeight = totalWeight + scaleDown(weight, 18);
+        totalWeight = totalWeight.plus(scaleDown(weight, 18));
       }
       pool.totalWeight = totalWeight;
     }
@@ -56,7 +56,7 @@ export function updatePoolWeights(poolId: string, blockTimestamp: BigInt): void 
           poolToken.weight = weight;
           poolToken.save();
         }
-        totalWeight = totalWeight + weight;
+        totalWeight = totalWeight.plus(weight);
       }
       pool.totalWeight = totalWeight;
     }
@@ -73,21 +73,21 @@ function calculateCurrentWeight(
 ): BigDecimal {
   const scalar: BigDecimal = BigDecimal.fromString('1000000000000000000');
 
-  if (blockTimestamp >= endTimestamp || startWeight == endWeight) {
-    return endWeight.toBigDecimal() / scalar;
-  } else if (blockTimestamp <= startTimestamp) {
-    return startWeight.toBigDecimal() / scalar;
+  if (blockTimestamp.ge(endTimestamp) || startWeight.equals(endWeight)) {
+    return endWeight.toBigDecimal().div(scalar);
+  } else if (blockTimestamp.le(startTimestamp)) {
+    return startWeight.toBigDecimal().div(scalar);
   } else {
-    const duration: BigInt = endTimestamp - startTimestamp;
-    const elapsedTime: BigInt = blockTimestamp - startTimestamp;
-    const pctProgress: BigDecimal = elapsedTime.toBigDecimal() / duration.toBigDecimal();
+    const duration: BigInt = endTimestamp.minus(startTimestamp);
+    const elapsedTime: BigInt = blockTimestamp.minus(startTimestamp);
+    const pctProgress: BigDecimal = elapsedTime.toBigDecimal().div(duration.toBigDecimal());
 
-    if (startWeight > endWeight) {
-      let delta = pctProgress * (startWeight - endWeight).toBigDecimal();
-      return (startWeight.toBigDecimal() - delta) / scalar;
+    if (startWeight.gt(endWeight)) {
+      let delta = pctProgress.times((startWeight - endWeight).toBigDecimal());
+      return startWeight.toBigDecimal().minus(delta).div(scalar).truncate(18);
     } else {
-      let delta = pctProgress * (endWeight - startWeight).toBigDecimal();
-      return (startWeight.toBigDecimal() + delta) / scalar;
+      let delta = pctProgress.times((endWeight - startWeight).toBigDecimal());
+      return startWeight.toBigDecimal().plus(delta).div(scalar).truncate(18);
     }
   }
 }

--- a/src/mappings/helpers/weighted.ts
+++ b/src/mappings/helpers/weighted.ts
@@ -77,13 +77,13 @@ function calculateCurrentWeight(
     const totalSeconds: BigInt = endTimestamp.minus(startTimestamp);
     const secondsElapsed: BigInt = blockTimestamp.minus(startTimestamp);
     pctProgress = secondsElapsed.div(totalSeconds);
-      if (startWeight.gt(endWeight)) {
+    if (startWeight.gt(endWeight)) {
       delta = pctProgress.times(startWeight.minus(endWeight));
       currentWeight = startWeight.minus(delta);
-      } else {
+    } else {
       delta = pctProgress.times(endWeight.minus(startWeight));
       currentWeight = startWeight.plus(delta);
-      }
+    }
   }
   currentWeight = scaleDown(currentWeight, 18);
   return currentWeight;

--- a/src/mappings/helpers/weighted.ts
+++ b/src/mappings/helpers/weighted.ts
@@ -1,7 +1,6 @@
 import { Address, BigInt, Bytes } from '@graphprotocol/graph-ts';
 
 import { Pool, GradualWeightUpdate } from '../../types/schema';
-import { WeightedPool } from '../../types/templates/WeightedPool/WeightedPool';
 
 import { ZERO_BD, ONE, ZERO } from './constants';
 import { scaleDown, loadPoolToken } from './misc';

--- a/src/mappings/helpers/weighted.ts
+++ b/src/mappings/helpers/weighted.ts
@@ -21,7 +21,7 @@ export function updatePoolWeights(poolId: string, blockTimestamp: BigInt): void 
 
   let latestWeightUpdateId = pool.latestWeightUpdate;
   let weights: BigInt[] = [];
-  let latestWeightUpdate: GradualWeightUpdate = null;
+  let latestUpdate: GradualWeightUpdate = null;
 
   if (!latestWeightUpdateId) {
     let poolContract = WeightedPool.bind(changetype<Address>(pool.address));

--- a/src/mappings/helpers/weighted.ts
+++ b/src/mappings/helpers/weighted.ts
@@ -47,8 +47,6 @@ export function updatePoolWeights(poolId: string, blockTimestamp: BigInt): void 
   if (pool == null) return;
 
   const poolAddress = pool.address;
-  let poolContract = WeightedPool.bind(changetype<Address>(poolAddress));
-
   let tokensList = new Array<Bytes>();
   for (let i = 0; i < pool.tokensList.length; i++) {
     let tokenAddress = pool.tokensList[i];

--- a/src/mappings/helpers/weighted.ts
+++ b/src/mappings/helpers/weighted.ts
@@ -21,12 +21,15 @@ export function updatePoolWeights(poolId: string, blockTimestamp: BigInt): void 
 
   let latestWeightUpdateId = pool.latestWeightUpdate;
   let weights: BigInt[] = [];
+  let latestWeightUpdate: GradualWeightUpdate = null;
+
   if (!latestWeightUpdateId) {
     let poolContract = WeightedPool.bind(changetype<Address>(pool.address));
     let weightsCall = poolContract.try_getNormalizedWeights();
     weights = weightsCall.value;
+  } else {
+      latestUpdate = GradualWeightUpdate.load(latestWeightUpdateId) as GradualWeightUpdate;
   }
-  let latestUpdate = GradualWeightUpdate.load(latestWeightUpdateId) as GradualWeightUpdate;
 
   if (latestUpdate.startWeights.length == tokensList.length || weights.length == tokensList.length) {
     let totalWeight = ZERO_BD;

--- a/src/mappings/helpers/weighted.ts
+++ b/src/mappings/helpers/weighted.ts
@@ -21,14 +21,14 @@ export function updatePoolWeights(poolId: string, blockTimestamp: BigInt): void 
 
   let latestWeightUpdateId = pool.latestWeightUpdate;
   let weights: BigInt[] = [];
-  let latestUpdate: GradualWeightUpdate = null;
+  let latestUpdate = null;
 
-  if (!latestWeightUpdateId) {
+  if (latestWeightUpdateId === null) {
     let poolContract = WeightedPool.bind(changetype<Address>(pool.address));
     let weightsCall = poolContract.try_getNormalizedWeights();
     weights = weightsCall.value;
   } else {
-      latestUpdate = GradualWeightUpdate.load(latestWeightUpdateId) as GradualWeightUpdate;
+    latestUpdate = GradualWeightUpdate.load(latestWeightUpdateId) as GradualWeightUpdate;
   }
 
   if (latestUpdate.startWeights.length == tokensList.length || weights.length == tokensList.length) {

--- a/src/mappings/poolController.ts
+++ b/src/mappings/poolController.ts
@@ -329,7 +329,7 @@ export function handleGradualWeightUpdateScheduled(event: GradualWeightUpdateSch
 
   let id = event.transaction.hash.toHexString().concat(event.transactionLogIndex.toString());
   let weightUpdate = new GradualWeightUpdate(id);
-  weightUpdate.poolId = poolContract.pool;
+  weightUpdate.poolId = poolId;
   weightUpdate.scheduledTimestamp = event.block.timestamp.toI32();
   weightUpdate.startTimestamp = event.params.startTime;
   weightUpdate.endTimestamp = event.params.endTime;

--- a/src/mappings/poolController.ts
+++ b/src/mappings/poolController.ts
@@ -58,6 +58,7 @@ import {
 } from './helpers/misc';
 import { ONE_BD, ProtocolFeeType, ZERO_ADDRESS, ZERO_BD } from './helpers/constants';
 import { updateAmpFactor } from './helpers/stable';
+import { updatePoolWeights } from './helpers/weighted';
 import { getPoolTokenManager, getPoolTokens } from './helpers/pools';
 import {
   ProtocolFeePercentageCacheUpdated,

--- a/src/mappings/poolController.ts
+++ b/src/mappings/poolController.ts
@@ -324,6 +324,8 @@ export function handleGradualWeightUpdateScheduled(event: GradualWeightUpdateSch
   let poolContract = PoolContract.load(poolAddress.toHexString());
   if (poolContract == null) return;
 
+  let poolId = poolContract.pool;
+
   let id = event.transaction.hash.toHexString().concat(event.transactionLogIndex.toString());
   let weightUpdate = new GradualWeightUpdate(id);
   weightUpdate.poolId = poolContract.pool;
@@ -333,6 +335,14 @@ export function handleGradualWeightUpdateScheduled(event: GradualWeightUpdateSch
   weightUpdate.startWeights = event.params.startWeights;
   weightUpdate.endWeights = event.params.endWeights;
   weightUpdate.save();
+
+  let pool = Pool.load(poolId);
+  if (pool == null) return;
+
+  pool.latestWeightUpdate = weightUpdate.id;
+  pool.save();
+
+  updatePoolWeights(poolId, event.block.timestamp);
 }
 
 /************************************

--- a/src/mappings/poolFactory.ts
+++ b/src/mappings/poolFactory.ts
@@ -105,7 +105,7 @@ function createWeightedLikePool(event: PoolCreated, poolType: string, poolTypeVe
   handleNewPoolTokens(pool, tokens);
 
   // Load pool with initial weights
-  updatePoolWeights(poolId.toHexString());
+  updatePoolWeights(poolId.toHexString(), event.block.timestamp);
 
   // Create PriceRateProvider entities for WeightedPoolV2+
   if (poolType == PoolType.Weighted && poolTypeVersion >= 2) {

--- a/src/mappings/vault.ts
+++ b/src/mappings/vault.ts
@@ -481,7 +481,6 @@ export function handleSwapEvent(event: SwapEvent): void {
   if (isVariableWeightPool(pool)) {
     // Some pools' weights update over time so we need to update them after each swap
     updatePoolWeights(poolId.toHexString(), event.block.timestamp);
-    log.debug('updatePoolWeights called: {}', [poolId.toHexString()]);
   } else if (isStableLikePool(pool)) {
     // Stablelike pools' amplification factors update over time so we need to update them after each swap
     updateAmpFactor(pool, event.block.timestamp);

--- a/src/mappings/vault.ts
+++ b/src/mappings/vault.ts
@@ -517,7 +517,7 @@ export function handleSwapEvent(event: SwapEvent): void {
 
   let logIndex = event.logIndex;
   let transactionHash = event.transaction.hash;
-  let blockTimestamp = blockTimestamp.toI32();
+  blockTimestamp = blockTimestamp.toI32();
 
   let poolTokenIn = loadPoolToken(poolId.toHexString(), tokenInAddress);
   let poolTokenOut = loadPoolToken(poolId.toHexString(), tokenOutAddress);

--- a/src/mappings/vault.ts
+++ b/src/mappings/vault.ts
@@ -480,7 +480,8 @@ export function handleSwapEvent(event: SwapEvent): void {
 
   if (isVariableWeightPool(pool)) {
     // Some pools' weights update over time so we need to update them after each swap
-    updatePoolWeights(poolId.toHexString());
+    updatePoolWeights(poolId.toHexString(), event.block.timestamp);
+
   } else if (isStableLikePool(pool)) {
     // Stablelike pools' amplification factors update over time so we need to update them after each swap
     updateAmpFactor(pool, event.block.timestamp);

--- a/src/mappings/vault.ts
+++ b/src/mappings/vault.ts
@@ -481,6 +481,7 @@ export function handleSwapEvent(event: SwapEvent): void {
   if (isVariableWeightPool(pool)) {
     // Some pools' weights update over time so we need to update them after each swap
     updatePoolWeights(poolId.toHexString(), event.block.timestamp);
+    log.info('updatePoolWeights called: {}', [poolId.toHexString()])
   } else if (isStableLikePool(pool)) {
     // Stablelike pools' amplification factors update over time so we need to update them after each swap
     updateAmpFactor(pool, event.block.timestamp);

--- a/src/mappings/vault.ts
+++ b/src/mappings/vault.ts
@@ -517,7 +517,7 @@ export function handleSwapEvent(event: SwapEvent): void {
 
   let logIndex = event.logIndex;
   let transactionHash = event.transaction.hash;
-  blockTimestamp = blockTimestamp.toI32();
+  blockTimestamp = event.block.timestamp.toI32();
 
   let poolTokenIn = loadPoolToken(poolId.toHexString(), tokenInAddress);
   let poolTokenOut = loadPoolToken(poolId.toHexString(), tokenOutAddress);

--- a/src/mappings/vault.ts
+++ b/src/mappings/vault.ts
@@ -517,7 +517,7 @@ export function handleSwapEvent(event: SwapEvent): void {
 
   let logIndex = event.logIndex;
   let transactionHash = event.transaction.hash;
-  blockTimestamp = event.block.timestamp.toI32();
+  let blockTimestamp = event.block.timestamp.toI32();
 
   let poolTokenIn = loadPoolToken(poolId.toHexString(), tokenInAddress);
   let poolTokenOut = loadPoolToken(poolId.toHexString(), tokenOutAddress);

--- a/src/mappings/vault.ts
+++ b/src/mappings/vault.ts
@@ -481,7 +481,6 @@ export function handleSwapEvent(event: SwapEvent): void {
   if (isVariableWeightPool(pool)) {
     // Some pools' weights update over time so we need to update them after each swap
     updatePoolWeights(poolId.toHexString(), event.block.timestamp);
-
   } else if (isStableLikePool(pool)) {
     // Stablelike pools' amplification factors update over time so we need to update them after each swap
     updateAmpFactor(pool, event.block.timestamp);

--- a/src/mappings/vault.ts
+++ b/src/mappings/vault.ts
@@ -478,13 +478,14 @@ export function handleSwapEvent(event: SwapEvent): void {
   //   pool.swapEnabled = true;
   // }
 
+  let blockTimestamp = event.block.timestamp;
   if (isVariableWeightPool(pool)) {
     // Some pools' weights update over time so we need to update them after each swap
-    updatePoolWeights(poolId.toHexString(), event.block.timestamp);
+    updatePoolWeights(poolId.toHexString(), blockTimestamp);
     log.debug('updatePoolWeights called: {}', [poolId.toHexString()]);
   } else if (isStableLikePool(pool)) {
     // Stablelike pools' amplification factors update over time so we need to update them after each swap
-    updateAmpFactor(pool, event.block.timestamp);
+    updateAmpFactor(pool, blockTimestamp);
   }
 
   // If swapping on a pool with preminted BPT and the BPT itself is being swapped then this is equivalent to a mint/burn in a regular pool
@@ -516,7 +517,7 @@ export function handleSwapEvent(event: SwapEvent): void {
 
   let logIndex = event.logIndex;
   let transactionHash = event.transaction.hash;
-  let blockTimestamp = event.block.timestamp.toI32();
+  let blockTimestamp = blockTimestamp.toI32();
 
   let poolTokenIn = loadPoolToken(poolId.toHexString(), tokenInAddress);
   let poolTokenOut = loadPoolToken(poolId.toHexString(), tokenOutAddress);

--- a/src/mappings/vault.ts
+++ b/src/mappings/vault.ts
@@ -478,14 +478,13 @@ export function handleSwapEvent(event: SwapEvent): void {
   //   pool.swapEnabled = true;
   // }
 
-  let blockTimestamp = event.block.timestamp;
   if (isVariableWeightPool(pool)) {
     // Some pools' weights update over time so we need to update them after each swap
-    updatePoolWeights(poolId.toHexString(), blockTimestamp);
+    updatePoolWeights(poolId.toHexString(), event.block.timestamp);
     log.debug('updatePoolWeights called: {}', [poolId.toHexString()]);
   } else if (isStableLikePool(pool)) {
     // Stablelike pools' amplification factors update over time so we need to update them after each swap
-    updateAmpFactor(pool, blockTimestamp);
+    updateAmpFactor(pool, event.block.timestamp);
   }
 
   // If swapping on a pool with preminted BPT and the BPT itself is being swapped then this is equivalent to a mint/burn in a regular pool

--- a/src/mappings/vault.ts
+++ b/src/mappings/vault.ts
@@ -481,7 +481,7 @@ export function handleSwapEvent(event: SwapEvent): void {
   if (isVariableWeightPool(pool)) {
     // Some pools' weights update over time so we need to update them after each swap
     updatePoolWeights(poolId.toHexString(), event.block.timestamp);
-    log.info('updatePoolWeights called: {}', [poolId.toHexString()])
+    log.debug('updatePoolWeights called: {}', [poolId.toHexString()]);
   } else if (isStableLikePool(pool)) {
     // Stablelike pools' amplification factors update over time so we need to update them after each swap
     updateAmpFactor(pool, event.block.timestamp);


### PR DESCRIPTION
# Description

Refactoring of the `updatePoolWeights` function to no longer uses calls to retrieve token weight information. Instead this token weight information is calculated given the block time and last `GradualWeightUpdateScheduled` event information.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [x] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas

### `dev` -> `master`
- [ ] I have [checked](https://balancer.github.io/balancer-subgraph-v2/status.html) that all beta deployments have synced
- [ ] I have [checked](https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-polygon-prune-v2-beta/graphql?query=%0A%7B%0A++balancers%28block%3A%7Bnumber%3A1%7D%29%7B%0A++++id%0A++%7D%0A%7D) that the earliest block in the polygon pruned deployment is [block, date/time](https://polygonscan.com/block/block)
  - [ ] The earliest block is more than 24 hours old
- [ ] I have checked that core metrics are the same in the beta and production deployments

### Merges to `dev`
- [ ] I have checked that the graft base is not a pruned deployment
