### PR TITLE
Issue #185 updates

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -274,6 +274,7 @@ type JoinExit @entity(immutable: true) {
   user: User!
   timestamp: Int!
   tx: Bytes!
+  block: BigInt!
 }
 
 type LatestPrice @entity {

--- a/schema.graphql
+++ b/schema.graphql
@@ -255,6 +255,7 @@ type Swap @entity(immutable: true) {
   poolId: Pool!
   userAddress: User!
   timestamp: Int!
+  block: BigInt!
   tx: Bytes!
 }
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -3,6 +3,7 @@ type Balancer @entity {
   id: ID!
   poolCount: Int!
   pools: [Pool!] @derivedFrom(field: "vaultID")
+  snapshots: [BalancerSnapshot!] @derivedFrom(field: "vault")
 
   totalLiquidity: BigDecimal!
   totalSwapCount: BigInt!
@@ -22,16 +23,16 @@ type Pool @entity {
   oracleEnabled: Boolean!
   symbol: String
   name: String
-  
+
   "Indicates if a pool can be swapped against. Combines multiple sources, including offchain curation"
   swapEnabled: Boolean!
-  
+
   "The native swapEnabled boolean. internal to the pool. Only applies to Gyro, LBPs and InvestmentPools"
   swapEnabledInternal: Boolean
-  
+
   "External indication from an offchain permissioned actor"
   swapEnabledCurationSignal: Boolean
-  
+
   swapFee: BigDecimal!
   owner: Bytes
   isPaused: Boolean
@@ -53,6 +54,7 @@ type Pool @entity {
   tokensList: [Bytes!]!
 
   tokens: [PoolToken!] @derivedFrom(field: "poolId")
+  joinsExits: [JoinExit!] @derivedFrom(field: "pool")
   swaps: [Swap!] @derivedFrom(field: "poolId")
   shares: [PoolShare!] @derivedFrom(field: "poolId")
   snapshots: [PoolSnapshot!] @derivedFrom(field: "pool")

--- a/src/mappings/vault.ts
+++ b/src/mappings/vault.ts
@@ -190,6 +190,7 @@ function handlePoolJoined(event: PoolBalanceChanged): void {
   join.timestamp = blockTimestamp;
   join.tx = transactionHash;
   join.valueUSD = valueUSD;
+  join.block = event.block.number;
   join.save();
 
   let protocolFeeUSD = ZERO_BD;
@@ -329,6 +330,7 @@ function handlePoolExited(event: PoolBalanceChanged): void {
   exit.timestamp = blockTimestamp;
   exit.tx = transactionHash;
   exit.valueUSD = valueUSD;
+  exit.block = event.block.number;
   exit.save();
 
   let protocolFeeUSD = ZERO_BD;

--- a/src/mappings/vault.ts
+++ b/src/mappings/vault.ts
@@ -617,6 +617,7 @@ export function handleSwapEvent(event: SwapEvent): void {
 
   swap.timestamp = blockTimestamp;
   swap.tx = transactionHash;
+  swap.block = event.block.number;
   swap.save();
 
   // update pool swapsCount


### PR DESCRIPTION
# Description

This PR address changes requested in issue #185. 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas

### `dev` -> `master`
- [ ] I have [checked](https://balancer.github.io/balancer-subgraph-v2/status.html) that all beta deployments have synced
- [ ] I have [checked](https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-polygon-prune-v2-beta/graphql?query=%0A%7B%0A++balancers%28block%3A%7Bnumber%3A1%7D%29%7B%0A++++id%0A++%7D%0A%7D) that the earliest block in the polygon pruned deployment is [block, date/time](https://polygonscan.com/block/block)
  - [ ] The earliest block is more than 24 hours old
- [ ] I have checked that core metrics are the same in the beta and production deployments

### Merges to `dev`
- [ ] I have checked that the graft base is not a pruned deployment
