### PR TITLE
Managed kassandra 

### DIFF
--- a/abis/ManagedKassandraPoolControllerFactory.json
+++ b/abis/ManagedKassandraPoolControllerFactory.json
@@ -1,0 +1,485 @@
+[
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "caller",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "vaultPoolId",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "poolController",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "whitelist",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "isPrivatePool",
+        "type": "bool"
+      }
+    ],
+    "name": "KassandraPoolCreated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "vaultPoolId",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "string",
+        "name": "tokenName",
+        "type": "string"
+      },
+      {
+        "indexed": false,
+        "internalType": "string",
+        "name": "tokenSymbol",
+        "type": "string"
+      },
+      {
+        "indexed": false,
+        "internalType": "contract IERC20[]",
+        "name": "tokens",
+        "type": "address[]"
+      }
+    ],
+    "name": "KassandraPoolCreatedTokens",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "previousOwner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "OwnershipTransferred",
+    "type": "event"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "internalType": "string",
+            "name": "name",
+            "type": "string"
+          },
+          {
+            "internalType": "string",
+            "name": "symbol",
+            "type": "string"
+          },
+          {
+            "internalType": "bool",
+            "name": "isPrivatePool",
+            "type": "bool"
+          },
+          {
+            "internalType": "contract IWhitelist",
+            "name": "whitelist",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256[]",
+            "name": "amountsIn",
+            "type": "uint256[]"
+          }
+        ],
+        "internalType": "struct KassandraControlledManagedPoolFactory.PoolParams",
+        "name": "poolParams",
+        "type": "tuple"
+      },
+      {
+        "components": [
+          {
+            "internalType": "contract IERC20[]",
+            "name": "tokens",
+            "type": "address[]"
+          },
+          {
+            "internalType": "uint256[]",
+            "name": "normalizedWeights",
+            "type": "uint256[]"
+          },
+          {
+            "internalType": "uint256",
+            "name": "swapFeePercentage",
+            "type": "uint256"
+          },
+          {
+            "internalType": "bool",
+            "name": "swapEnabledOnStart",
+            "type": "bool"
+          },
+          {
+            "internalType": "bool",
+            "name": "mustAllowlistLPs",
+            "type": "bool"
+          },
+          {
+            "internalType": "uint256",
+            "name": "managementAumFeePercentage",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "aumFeeId",
+            "type": "uint256"
+          }
+        ],
+        "internalType": "struct ManagedPoolSettings.ManagedPoolSettingsParams",
+        "name": "settingsParams",
+        "type": "tuple"
+      },
+      {
+        "components": [
+          {
+            "internalType": "uint64",
+            "name": "feesToManager",
+            "type": "uint64"
+          },
+          {
+            "internalType": "uint64",
+            "name": "feesToReferral",
+            "type": "uint64"
+          }
+        ],
+        "internalType": "struct KassandraManagedPoolController.FeesPercentages",
+        "name": "feesSettings",
+        "type": "tuple"
+      },
+      {
+        "components": [
+          {
+            "internalType": "contract IERC20",
+            "name": "tokenIn",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "amountIn",
+            "type": "uint256"
+          },
+          {
+            "internalType": "bytes[]",
+            "name": "datas",
+            "type": "bytes[]"
+          }
+        ],
+        "internalType": "struct KassandraControlledManagedPoolFactory.JoinParams",
+        "name": "joinParams",
+        "type": "tuple"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "salt",
+        "type": "bytes32"
+      }
+    ],
+    "name": "create",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      },
+      {
+        "internalType": "contract KassandraManagedPoolController",
+        "name": "poolController",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getAssetManager",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getAuthorizedManagers",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getKassandraRules",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getManagedPoolFactory",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getPrivateInvestors",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getProxyInvest",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getProxyProviderTransfer",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getSwapProvider",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getVault",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getWETH",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "factory",
+        "type": "address"
+      },
+      {
+        "internalType": "contract IPrivateInvestors",
+        "name": "privateInvestors",
+        "type": "address"
+      },
+      {
+        "internalType": "contract IAuthorizedManagers",
+        "name": "authorizationContract",
+        "type": "address"
+      },
+      {
+        "internalType": "contract IVault",
+        "name": "vault",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "rules",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "assetManagerAddress",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "proxyInvest",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "swapProvider",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "proxyProviderTransfer",
+        "type": "address"
+      },
+      {
+        "internalType": "contract IWETH",
+        "name": "weth",
+        "type": "address"
+      }
+    ],
+    "name": "initialize",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      }
+    ],
+    "name": "isPoolFromFactory",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "kassandraAumFeePercentage",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "owner",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "renounceOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "transferOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]

--- a/manifest.template.yaml
+++ b/manifest.template.yaml
@@ -463,6 +463,28 @@ dataSources:
         - event: PoolCreated(indexed address)
           handler: handleNewManagedPoolV2
   {{/if}}
+  {{#if ManagedKassandraPoolControllerFactory}}
+  - kind: ethereum/contract
+    name: ManagedKassandraPoolControllerFactory
+    network: {{network}}
+    source:
+      address: '{{ManagedKassandraPoolControllerFactory.address}}'
+      abi: ManagedKassandraPoolControllerFactory
+      startBlock: {{ManagedKassandraPoolControllerFactory.startBlock}}
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.5
+      language: wasm/assemblyscript
+      file: ./src/mappings/poolFactory.ts
+      entities:
+        - Pool
+      abis:
+        - name: ManagedKassandraPoolControllerFactory
+          file: ./abis/ManagedKassandraPoolControllerFactory.json
+      eventHandlers:
+        - event: KassandraPoolCreated(indexed address,indexed bytes32,indexed address,address,address,bool)
+          handler: handleNewManagedKassandraPool
+  {{/if}}
   {{#if ConvergentPoolFactory}}
   - kind: ethereum/contract
     name: ConvergentPoolFactory

--- a/networks.yaml
+++ b/networks.yaml
@@ -66,9 +66,6 @@ mainnet:
   ManagedPoolV2Factory:
     address: "0xBF904F9F340745B4f0c4702c7B6Ab1e808eA6b93"
     startBlock: 17046230
-  ManagedKassandraPoolControllerFactory:
-    address: "0x228885c9d0440Ae640B88fBeE31522CC6a59Fd2F"
-    startBlock: 42020509
   ConvergentPoolFactory:
     address: "0xb7561f547F3207eDb42A6AfA42170Cd47ADD17BD"
     startBlock: 12686198
@@ -294,6 +291,9 @@ polygon:
   ManagedPoolV2Factory:
     address: "0xB8Dfa4fd0F083de2B7EDc0D5eeD5E684e54bA45D"
     startBlock: 41501253
+  ManagedKassandraPoolControllerFactory:
+    address: "0x228885c9d0440Ae640B88fBeE31522CC6a59Fd2F"
+    startBlock: 42020509
   StablePhantomPoolFactory:
     address: "0xC128a9954e6c874eA3d62ce62B468bA073093F25"
     startBlock: 22288478
@@ -416,6 +416,9 @@ arbitrum:
   ManagedPoolV2Factory:
     address: "0x8eA89804145c007e7D226001A96955ad53836087"
     startBlock: 80173649
+  ManagedKassandraPoolControllerFactory:
+    address: "0xF9c9073590F502F12B5497ae49DA1446D224A9EA"
+    startBlock: 120161662
   ERC4626LinearPoolFactory:
     address: "0x2794953110874981a0d301286c986992022A62a1"
     startBlock: 9311471
@@ -658,6 +661,9 @@ avalanche:
   ManagedPoolV2Factory:
     address: "0x03F3Fb107e74F2EAC9358862E91ad3c692712054"
     startBlock: 29221742
+  ManagedKassandraPoolControllerFactory:
+    address: "0xbBa46B512a158aF0e41111109617c660Ff903819"
+    startBlock: 34853589
   AaveLinearPoolV5Factory:
     address: "0x6caf662b573F577DE01165d2d38D1910bba41F8A"
     startBlock: 29512658

--- a/networks.yaml
+++ b/networks.yaml
@@ -66,6 +66,9 @@ mainnet:
   ManagedPoolV2Factory:
     address: "0xBF904F9F340745B4f0c4702c7B6Ab1e808eA6b93"
     startBlock: 17046230
+  ManagedKassandraPoolControllerFactory:
+    address: "0x228885c9d0440Ae640B88fBeE31522CC6a59Fd2F"
+    startBlock: 42020509
   ConvergentPoolFactory:
     address: "0xb7561f547F3207eDb42A6AfA42170Cd47ADD17BD"
     startBlock: 12686198

--- a/schema.graphql
+++ b/schema.graphql
@@ -22,16 +22,16 @@ type Pool @entity {
   oracleEnabled: Boolean!
   symbol: String
   name: String
-  
+
   "Indicates if a pool can be swapped against. Combines multiple sources, including offchain curation"
   swapEnabled: Boolean!
-  
+
   "The native swapEnabled boolean. internal to the pool. Only applies to Gyro, LBPs and InvestmentPools"
   swapEnabledInternal: Boolean
-  
+
   "External indication from an offchain permissioned actor"
   swapEnabledCurationSignal: Boolean
-  
+
   swapFee: BigDecimal!
   owner: Bytes
   isPaused: Boolean
@@ -83,7 +83,6 @@ type Pool @entity {
   mustAllowlistLPs: Boolean
   managementAumFee: BigDecimal
   totalAumFeeCollectedInBPT: BigDecimal
-  controllerFactory: Bytes
   circuitBreakers: [CircuitBreaker!] @derivedFrom(field: "pool")
 
   # LinearPool Only

--- a/schema.graphql
+++ b/schema.graphql
@@ -83,6 +83,7 @@ type Pool @entity {
   mustAllowlistLPs: Boolean
   managementAumFee: BigDecimal
   totalAumFeeCollectedInBPT: BigDecimal
+  controllerFactory: Bytes
   circuitBreakers: [CircuitBreaker!] @derivedFrom(field: "pool")
 
   # LinearPool Only

--- a/src/mappings/helpers/pools.ts
+++ b/src/mappings/helpers/pools.ts
@@ -32,6 +32,32 @@ export namespace PoolType {
   export const FX = 'FX';
 }
 
+export const poolTypes = [
+  PoolType.Weighted,
+  PoolType.Stable,
+  PoolType.MetaStable,
+  PoolType.Element,
+  PoolType.LiquidityBootstrapping,
+  PoolType.Investment,
+  PoolType.Managed,
+  PoolType.KassandraManaged,
+  PoolType.StablePhantom,
+  PoolType.ComposableStable,
+  PoolType.HighAmpComposableStable,
+  PoolType.AaveLinear,
+  PoolType.ERC4626Linear,
+  PoolType.EulerLinear,
+  PoolType.GearboxLinear,
+  PoolType.MidasLinear,
+  PoolType.ReaperLinear,
+  PoolType.SiloLinear,
+  PoolType.YearnLinear,
+  PoolType.Gyro2,
+  PoolType.Gyro3,
+  PoolType.GyroE,
+  PoolType.FX,
+];
+
 export function isVariableWeightPool(pool: Pool): boolean {
   return pool.poolType == PoolType.LiquidityBootstrapping || pool.poolType == PoolType.Investment;
 }

--- a/src/mappings/helpers/pools.ts
+++ b/src/mappings/helpers/pools.ts
@@ -14,6 +14,7 @@ export namespace PoolType {
   export const LiquidityBootstrapping = 'LiquidityBootstrapping';
   export const Investment = 'Investment';
   export const Managed = 'Managed';
+  export const KassandraManaged = 'KassandraManaged';
   export const StablePhantom = 'StablePhantom';
   export const ComposableStable = 'ComposableStable';
   export const HighAmpComposableStable = 'HighAmpComposableStable';
@@ -46,9 +47,13 @@ export function hasVirtualSupply(pool: Pool): boolean {
     pool.poolType == PoolType.SiloLinear ||
     pool.poolType == PoolType.YearnLinear ||
     pool.poolType == PoolType.StablePhantom ||
-    pool.poolType == PoolType.Managed ||
-    isComposableStablePool(pool)
+    isComposableStablePool(pool) ||
+    isManagedPool(pool)
   );
+}
+
+export function isManagedPool(pool: Pool): boolean {
+  return pool.poolType == PoolType.Managed || pool.poolType == PoolType.KassandraManaged;
 }
 
 export function isComposableStablePool(pool: Pool): boolean {

--- a/src/mappings/poolFactory.ts
+++ b/src/mappings/poolFactory.ts
@@ -26,6 +26,7 @@ import { PoolCreated } from '../types/WeightedPoolFactory/WeightedPoolFactory';
 import { AaveLinearPoolCreated } from '../types/AaveLinearPoolV3Factory/AaveLinearPoolV3Factory';
 import { ProtocolIdRegistered } from '../types/ProtocolIdRegistry/ProtocolIdRegistry';
 import { Balancer, Pool, PoolContract, ProtocolIdData } from '../types/schema';
+import { KassandraPoolCreated } from '../types/ManagedKassandraPoolControllerFactory/ManagedKassandraPoolControllerFactory';
 
 // datasource
 import { OffchainAggregator, WeightedPool as WeightedPoolTemplate } from '../types/templates';
@@ -160,6 +161,12 @@ export function handleNewManagedPoolV2(event: PoolCreated): void {
   const pool = createWeightedLikePool(event, PoolType.Managed, 2);
   if (pool == null) return;
   ManagedPoolTemplate.create(event.params.pool);
+}
+
+export function handleNewManagedKassandraPool(event: KassandraPoolCreated): void {
+  const pool = Pool.load(event.params.vaultPoolId.toHexString());
+  if (pool == null) return;
+  pool.controllerFactory = event.address;
 }
 
 function createStableLikePool(event: PoolCreated, poolType: string, poolTypeVersion: i32 = 1): string | null {

--- a/src/mappings/poolFactory.ts
+++ b/src/mappings/poolFactory.ts
@@ -167,6 +167,7 @@ export function handleNewManagedKassandraPool(event: KassandraPoolCreated): void
   const pool = Pool.load(event.params.vaultPoolId.toHexString());
   if (pool == null) return;
   pool.controllerFactory = event.address;
+  pool.save();
 }
 
 function createStableLikePool(event: PoolCreated, poolType: string, poolTypeVersion: i32 = 1): string | null {

--- a/src/mappings/vault.ts
+++ b/src/mappings/vault.ts
@@ -63,6 +63,7 @@ import {
   isLinearPool,
   isFXPool,
   isComposableStablePool,
+  isManagedPool,
 } from './helpers/pools';
 import { calculateInvariant, AMP_PRECISION, updateAmpFactor } from './helpers/stable';
 import { USDC_ADDRESS } from './helpers/assets';
@@ -255,7 +256,7 @@ function handlePoolJoined(event: PoolBalanceChanged): void {
   // with a non-zero value for the BPT amount when the pool is initialized,
   // when the amount of BPT informed in the event corresponds to the "excess" BPT that was preminted
   // and therefore must be subtracted from totalShares
-  if (pool.poolType == PoolType.Managed || pool.poolType == PoolType.StablePhantom || isComposableStablePool(pool)) {
+  if (pool.poolType == PoolType.StablePhantom || isComposableStablePool(pool) || isManagedPool(pool)) {
     let preMintedBpt = ZERO;
     let scaledPreMintedBpt = ZERO_BD;
     for (let i: i32 = 0; i < tokenAddresses.length; i++) {


### PR DESCRIPTION
# Description

~As there may be several types of managed pools, a new property 'controllerFactory' was created to differentiate them.~

We instead added a new `poolType` called `ManagedKassandra` in order to make it easier for SDK to integrate with it. As Subgraph already does the tracking of each factory, it's easier to do the mapping on our side instead of hard-coding controller factory addresses at the SDK.

Since Kassandra pools on Polygon have been created > 3 months ago and we're not re-syncing the Subgraph from that point, I also added a handler to the `EventEmitter` for us to be able to set `pool.poolType` manually.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other
