### PR TITLE
Update hardcoded VNXAU asset

### DIFF
--- a/assets.handlebars
+++ b/assets.handlebars
@@ -14,6 +14,9 @@ class Assets {
 export const {{symbol}}_ADDRESS = Address.fromString('{{address}}');
 {{/each}}
 
+export const VNXAU_ADDRESS = Address.fromString('{{VNXAU}}')
+
+
 export const assets: Assets = {
   stableAssets: [
     {{#each stableAssets}}

--- a/assets/mainnet.json
+++ b/assets/mainnet.json
@@ -119,8 +119,8 @@
       "assetSymbol": "EURS",
       "aggregator": "0x02F878A94a1AE1B15705aCD65b5519A46fe3517e",
       "aggregatorSymbol": "EUR/USD"
-    }
-        {
+    },
+    {
       "asset": "0x6d57B2E05F26C26b549231c866bdd39779e4a488",
       "assetSymbol": "VNXAU",
       "aggregator": "0xea5f70faa03f5C30B96029635C8d431d1A3cD1b8",

--- a/assets/mainnet.json
+++ b/assets/mainnet.json
@@ -15,19 +15,19 @@
   ],
   "pricingAssets": [
     {
-      "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2", 
+      "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
       "symbol": "WETH"
     },
     {
-      "address": "0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0", 
+      "address": "0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0",
       "symbol": "wstETH"
     },
     {
-      "address": "0x804CdB9116a10bB78768D3252355a1b18067bF8f", 
+      "address": "0x804CdB9116a10bB78768D3252355a1b18067bF8f",
       "symbol": "bb-a-DAI-V1"
     },
     {
-      "address": "0x9210F1204b5a24742Eba12f710636D76240dF3d0", 
+      "address": "0x9210F1204b5a24742Eba12f710636D76240dF3d0",
       "symbol": "bb-a-USDC-V1"
     },
     {
@@ -59,35 +59,35 @@
       "symbol": "bb-a-USDT-V3"
     },
     {
-      "address": "0xfeBb0bbf162E64fb9D0dfe186E517d84C395f016", 
+      "address": "0xfeBb0bbf162E64fb9D0dfe186E517d84C395f016",
       "symbol": "bb-a-USD-V3"
     },
     {
-      "address": "0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599", 
+      "address": "0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599",
       "symbol": "WBTC"
     },
     {
-      "address": "0xba100000625a3754423978a60c9317c58a424e3D", 
+      "address": "0xba100000625a3754423978a60c9317c58a424e3D",
       "symbol": "BAL"
     },
     {
-      "address": "0x9f8F72aA9304c8B593d555F12eF6589cC3A579A2", 
+      "address": "0x9f8F72aA9304c8B593d555F12eF6589cC3A579A2",
       "symbol": "MKR"
     },
     {
-      "address": "0x6810e776880C02933D47DB1b9fc05908e5386b96", 
+      "address": "0x6810e776880C02933D47DB1b9fc05908e5386b96",
       "symbol": "GNO"
     },
     {
-      "address": "0x5c6ee304399dbdb9c8ef030ab642b10820db8f56", 
+      "address": "0x5c6ee304399dbdb9c8ef030ab642b10820db8f56",
       "symbol": "B-80BAL-20WETH"
     },
     {
-      "address": "0x7D1AfA7B718fb893dB30A3aBc0Cfc608AaCfeBB0", 
+      "address": "0x7D1AfA7B718fb893dB30A3aBc0Cfc608AaCfeBB0",
       "symbol": "MATIC"
     },
     {
-      "address": "0xA13a9247ea42D743238089903570127DdA72fE44", 
+      "address": "0xA13a9247ea42D743238089903570127DdA72fE44",
       "symbol": "bb-a-USD"
     },
     {
@@ -120,7 +120,11 @@
       "aggregator": "0x02F878A94a1AE1B15705aCD65b5519A46fe3517e",
       "aggregatorSymbol": "EUR/USD"
     }
+        {
+      "asset": "0x6d57B2E05F26C26b549231c866bdd39779e4a488",
+      "assetSymbol": "VNXAU",
+      "aggregator": "0xea5f70faa03f5C30B96029635C8d431d1A3cD1b8",
+      "aggregatorSymbol": "XAU/USD"
+    }
   ]
 }
-
-

--- a/scripts/generate-assets.ts
+++ b/scripts/generate-assets.ts
@@ -9,8 +9,9 @@ const network = process.argv[2] || 'mainnet';
 const generateAssets = async (): Promise<void> => {
   const networksFilePath = path.resolve(__dirname, `../assets/${network}.json`);
   const config = yaml.load(await fs.readFile(networksFilePath, { encoding: 'utf-8' }));
+  const vnxau_asset = config.fxAssetAggregators.find((asset) => asset.assetSymbol == 'VNXAU');
+  config['VNXAU'] = vnxau_asset ? vnxau_asset.asset.toLowerCase() : '0x0000000000000000000000000000000000000000';
   config['network'] = network;
-
   const template = fs.readFileSync('assets.handlebars').toString();
   fs.writeFileSync('src/mappings/helpers/assets.ts', Handlebars.compile(template)(config));
 

--- a/src/mappings/helpers/assets.ts
+++ b/src/mappings/helpers/assets.ts
@@ -14,7 +14,7 @@ export const USDC_ADDRESS = Address.fromString('0xA0b86991c6218b36c1d19D4a2e9Eb0
 export const DAI_ADDRESS = Address.fromString('0x6B175474E89094C44Da98b954EedeAC495271d0F');
 export const USDT_ADDRESS = Address.fromString('0xdAC17F958D2ee523a2206206994597C13D831ec7');
 
-export const VNXAU_ADDRESS = Address.fromString('0x6d57B2E05F26C26b549231c866bdd39779e4a488')
+export const VNXAU_ADDRESS = Address.fromString('0x6d57b2e05f26c26b549231c866bdd39779e4a488')
 
 
 export const assets: Assets = {

--- a/src/mappings/helpers/assets.ts
+++ b/src/mappings/helpers/assets.ts
@@ -14,6 +14,9 @@ export const USDC_ADDRESS = Address.fromString('0xA0b86991c6218b36c1d19D4a2e9Eb0
 export const DAI_ADDRESS = Address.fromString('0x6B175474E89094C44Da98b954EedeAC495271d0F');
 export const USDT_ADDRESS = Address.fromString('0xdAC17F958D2ee523a2206206994597C13D831ec7');
 
+export const VNXAU_ADDRESS = Address.fromString('0x6d57B2E05F26C26b549231c866bdd39779e4a488')
+
+
 export const assets: Assets = {
   stableAssets: [
     Address.fromString('0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48'), // USDC
@@ -58,6 +61,10 @@ export const assets: Assets = {
     [
       Address.fromString('0xdB25f211AB05b1c97D595516F45794528a807ad8'), // EURS
       Address.fromString('0x02F878A94a1AE1B15705aCD65b5519A46fe3517e'), // EUR/USD
+    ],
+    [
+      Address.fromString('0x6d57B2E05F26C26b549231c866bdd39779e4a488'), // VNXAU
+      Address.fromString('0xea5f70faa03f5C30B96029635C8d431d1A3cD1b8'), // XAU/USD
     ],
   ],
 };

--- a/src/mappings/helpers/constants.ts
+++ b/src/mappings/helpers/constants.ts
@@ -43,7 +43,7 @@ let network: string = dataSource.network();
 // this list should be updated only if vault is deployed on a new chain
 // with an address different than the standard vanity address
 // in that case, AddressByNetwork and forNetwork must be updated accordingly
-// with a new entry for the new network - folowwing subgraph slugs
+// with a new entry for the new network - folowing subgraph slugs
 let vaultAddressByNetwork: AddressByNetwork = {
   canonical: '0xBA12222222228d8Ba445958a75a0704d566BF2C8',
   custom: '0x0000000000000000000000000000000000000000',

--- a/src/mappings/pricing.ts
+++ b/src/mappings/pricing.ts
@@ -1,5 +1,6 @@
 import { Address, Bytes, BigInt, BigDecimal, log, dataSource } from '@graphprotocol/graph-ts';
 import { Pool, TokenPrice, Balancer, PoolHistoricalLiquidity, LatestPrice, Token, FXOracle } from '../types/schema';
+import { VNXAU_ADDRESS } from './helpers/assets';
 import {
   ZERO_BD,
   PRICING_ASSETS,
@@ -408,7 +409,7 @@ export function handleAnswerUpdated(event: AnswerUpdated): void {
       token.fxOracleDecimals = 8; // @todo: get decimals on-chain
     }
 
-    if (tokenAddress == Address.fromString('0xc8bb8eda94931ca2f20ef43ea7dbd58e68400400')) {
+    if (tokenAddress == VNXAU_ADDRESS) {
       // XAU-USD oracle returns an answer with price unit of "USD per troy ounce"
       // For VNXAU however, we wanna use a price unit of "USD per gram"
       const divisor = '3110347680'; // 31.1034768 * 1e8 (31.10 gram per troy ounce)

--- a/src/mappings/pricing.ts
+++ b/src/mappings/pricing.ts
@@ -409,7 +409,7 @@ export function handleAnswerUpdated(event: AnswerUpdated): void {
       token.fxOracleDecimals = 8; // @todo: get decimals on-chain
     }
 
-    if (tokenAddress == VNXAU_ADDRESS) {
+    if (tokenAddress != ZERO_ADDRESS && tokenAddress == VNXAU_ADDRESS) {
       // XAU-USD oracle returns an answer with price unit of "USD per troy ounce"
       // For VNXAU however, we wanna use a price unit of "USD per gram"
       const divisor = '3110347680'; // 31.1034768 * 1e8 (31.10 gram per troy ounce)


### PR DESCRIPTION
# Description

Removed VNXAU hardcoded address and added logic to get it from config. Also updated the handlebars template for assets to just retrieve VNXAU_ADDRESS without looking in the array of fxAggregators every time. Added XAU/USD aggregator to the mainnet chain.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [x] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

`yarn codegen` and then `yarn generate-assets`, it should update helpers/assets.ts file with the new VNXAU_ADDRESS constant.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas

### Merges to `dev`
- [x] I have checked that the graft base is not a pruned deployment
