### PR TITLE
graft mainnet and optimism

### DIFF
--- a/networks.yaml
+++ b/networks.yaml
@@ -1,11 +1,11 @@
 mainnet:
   network: mainnet
   graft:
-    # FXPoolDeployer startBlock
-    # block: 18469425
+    # CSP V6 startBlock
+    block: 19314764
     # always make sure the base subgraph has not been pruned
     # it should be possible to run time travel queries on it going back to the vault's startBlock
-    # base: QmeYeqQgZysfHv4U4PYs5VzLDsxYSe79auxnp2G9kudpvT
+    base: QmPHyJwnezdwnvvc8tsBshrsVi61JqacX6RMc8JBDZTmc9
   EventEmitter:
     address: "0x1ACfEEA57d2ac674d7E65964f155AB9348A6C290"
     startBlock: 16419620
@@ -571,11 +571,11 @@ gnosis:
 optimism:
   network: optimism
   graft:
-    # GyroEPoolFactory start block
-    # block: 97253023
+    # CSP V6 start block
+    block: 116694338
     # always make sure the base subgraph has not been pruned
     # it should be possible to run time travel queries on it going back to the vault's startBlock
-    # base: QmRJyWfTacLi1dCQTDh57Q5nrEcL8td944yTZugzJRfWXM
+    base: QmYG3Ga4ipdhGCPaudZKatGXTbteoMLdkjBsxCUKDV6dwq
   Vault:
     address: "0xBA12222222228d8Ba445958a75a0704d566BF2C8"
     startBlock: 7003431


### PR DESCRIPTION
# Description

Ethereum and Optimism are indexing slower than expected. I'm grafting them to ensure they're ready when Polygon finishes its grafting.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [x] Other

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas

### Merges to `dev`
- [x] I have checked that the graft base is not a pruned deployment
