### PR TITLE
Multiple Quote Tokens support for FXPools: FXPoolDeployerTracker

### DIFF
--- a/abis/FXPoolDeployerTracker.json
+++ b/abis/FXPoolDeployerTracker.json
@@ -1,0 +1,134 @@
+[
+  {
+    "type": "function",
+    "name": "broadcastNewDeployer",
+    "inputs": [
+      {
+        "name": "_quoteToken",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "_deployer",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "fxPoolDeployers",
+    "inputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "owner",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "renounceOwnership",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setDeployer",
+    "inputs": [
+      {
+        "name": "_quoteToken",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "_deployer",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "transferOwnership",
+    "inputs": [
+      {
+        "name": "newOwner",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "event",
+    "name": "NewFXPoolDeployer",
+    "inputs": [
+      {
+        "name": "quoteToken",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "deployer",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "caller",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "OwnershipTransferred",
+    "inputs": [
+      {
+        "name": "previousOwner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "newOwner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  }
+]

--- a/manifest.template.yaml
+++ b/manifest.template.yaml
@@ -1662,6 +1662,43 @@ dataSources:
         - event: NewFXPool(indexed address,indexed bytes32,indexed address)
           handler: handleNewFXPoolV1
   {{/if}}
+  {{#if FXPoolDeployerTracker}}
+  - kind: ethereum/contract
+    name: FXPoolDeployerTracker
+    network: {{network}}
+    source:
+      address: '{{FXPoolDeployerTracker.address}}'
+      abi: FXPoolDeployerTracker
+      startBlock: {{FXPoolDeployerTracker.startBlock}}
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.5
+      language: wasm/assemblyscript
+      file: ./src/mappings/poolFactory.ts
+      entities:
+        - Balancer
+        - Pool
+      abis:
+        - name: Vault
+          file: ./abis/Vault.json
+        - name: ERC20
+          file: ./abis/ERC20.json
+        - name: WeightedPool
+          file: ./abis/WeightedPool.json
+        - name: FXPool
+          file: ./abis/FXPool.json
+        - name: FXPoolDeployer
+          file: ./abis/FXPoolDeployer.json
+        - name: FXPoolDeployerTracker
+          file: ./abis/FXPoolDeployerTracker.json
+        - name: Assimilator
+          file: ./abis/Assimilator.json
+        - name: ChainlinkPriceFeed
+          file: ./abis/ChainlinkPriceFeed.json
+      eventHandlers:
+        - event: NewFXPoolDeployer(indexed address,indexed address,indexed address)
+          handler: handleNewFXPoolDeployer
+  {{/if}}
   {{#if FXPoolDeployer}}
   - kind: ethereum/contract
     name: FXPoolDeployer
@@ -2324,6 +2361,40 @@ templates:
           handler: handlePauseGyroPool
         - event: UnpausedLocally()
           handler: handleUnpauseGyroPool
+  - kind: ethereum/contract
+    name: FXPoolDeployer
+    network: {{network}}
+    source:
+      abi: FXPoolDeployer
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.5
+      language: wasm/assemblyscript
+      file: ./src/mappings/poolController.ts
+      entities:
+        - Pool
+        - PoolShare
+        - Swap
+        - PoolToken
+        - GradualWeightUpdate
+      abis:
+        - name: Vault
+          file: ./abis/Vault.json
+        - name: ERC20
+          file: ./abis/ERC20.json
+        - name: WeightedPool
+          file: ./abis/WeightedPool.json
+        - name: FXPool
+          file: ./abis/FXPool.json
+        - name: FXPoolDeployer
+          file: ./abis/FXPoolDeployer.json
+        - name: Assimilator
+          file: ./abis/Assimilator.json
+        - name: ChainlinkPriceFeed
+          file: ./abis/ChainlinkPriceFeed.json
+      eventHandlers:
+        - event: NewFXPool(indexed address,indexed bytes32,indexed address)
+          handler: handleNewFXPoolV2
   - kind: ethereum/contract
     name: FXPool
     network: {{network}}

--- a/manifest.template.yaml
+++ b/manifest.template.yaml
@@ -2370,7 +2370,7 @@ templates:
       kind: ethereum/events
       apiVersion: 0.0.5
       language: wasm/assemblyscript
-      file: ./src/mappings/poolController.ts
+      file: ./src/mappings/poolFactory.ts
       entities:
         - Pool
         - PoolShare

--- a/networks.yaml
+++ b/networks.yaml
@@ -124,6 +124,9 @@ mainnet:
   FXPoolFactory:
     address: "0x81fE9e5B28dA92aE949b705DfDB225f7a7cc5134"
     startBlock: 15981805
+  FXPoolDeployerTracker:
+    address: "0x9E0d068Ede387888f8A24c92F7486920c200EfD5"
+    startBlock: 19417173
   FXPoolDeployer:
     address: "0xfb23Bc0D2629268442CD6521CF4170698967105f"
     startBlock: 18469425
@@ -352,6 +355,9 @@ polygon:
   FXPoolFactory:
     address: "0x627D759314D5c4007b461A74eBaFA7EBC5dFeD71"
     startBlock: 32054793
+  FXPoolDeployerTracker:
+    address: "0xa2fC51a7f5246a718848F5bdAdBc4a78191A8E2a"
+    startBlock: 54559455
   FXPoolDeployer:
     address: "0xF169c1Ae8De24Da43a3dC5c5F05De412b4848bD3"
     startBlock: 49368321

--- a/networks.yaml
+++ b/networks.yaml
@@ -465,6 +465,9 @@ arbitrum:
   GyroEV2PoolFactory:
     address: "0xdCA5f1F0d7994A32BC511e7dbA0259946653Eaf6"
     startBlock: 124858976
+  FXPoolDeployerTracker:
+    address: "0xEa0a6fcc52Fcea683f962b6Bfd7f4F93E3804EA8"
+    startBlock: 191573392
   FXPoolDeployer:
     address: "0x0bd5EC16658346eeCd5dE8c704a38Efe02B5DA69"
     startBlock: 183603904
@@ -692,6 +695,9 @@ avalanche:
   FXPoolDeployer:
     address: "0x4042dC4110Ea9500338737605A60065c3de152C6"
     startBlock: 37150792
+  FXPoolDeployerTracker:
+    address: "0x7ff7B43CEAc9a1163cCB525ac9Dc1dE9A8837b4B"
+    startBlock: 43049862
 basegoerli:
   network: base-testnet
   Vault:

--- a/src/mappings/poolFactory.ts
+++ b/src/mappings/poolFactory.ts
@@ -28,6 +28,7 @@ import { AaveLinearPoolCreated } from '../types/AaveLinearPoolV3Factory/AaveLine
 import { ProtocolIdRegistered } from '../types/ProtocolIdRegistry/ProtocolIdRegistry';
 import { Balancer, Pool, PoolContract, ProtocolIdData } from '../types/schema';
 import { KassandraPoolCreated } from '../types/ManagedKassandraPoolControllerFactory/ManagedKassandraPoolControllerFactory';
+import { NewFXPoolDeployer } from '../types/FXPoolDeployerTracker/FXPoolDeployerTracker';
 
 // datasource
 import { OffchainAggregator, WeightedPool as WeightedPoolTemplate } from '../types/templates';
@@ -46,6 +47,7 @@ import { Gyro2Pool as Gyro2PoolTemplate } from '../types/templates';
 import { Gyro3Pool as Gyro3PoolTemplate } from '../types/templates';
 import { GyroEPool as GyroEPoolTemplate } from '../types/templates';
 import { FXPool as FXPoolTemplate } from '../types/templates';
+import { FXPoolDeployer as FXPoolDeployerTemplate } from '../types/templates';
 
 import { WeightedPool } from '../types/templates/WeightedPool/WeightedPool';
 import { WeightedPoolV2 } from '../types/templates/WeightedPoolV2/WeightedPoolV2';
@@ -632,6 +634,10 @@ export function handleNewGyroEPool(event: PoolCreated): void {
 
 export function handleNewGyroEV2Pool(event: PoolCreated): void {
   createGyroEPool(event, 2);
+}
+
+export function handleNewFXPoolDeployer(event: NewFXPoolDeployer): void {
+  FXPoolDeployerTemplate.create(event.params.deployer);
 }
 
 export function handleNewFXPoolV1(event: ethereum.Event): void {


### PR DESCRIPTION
# Description

End of last year we added support for `FXPoolDeployer` ( #527 ) which basically acts as a factory contract for `FXPool`s: allows permissionless deployments of `FXPool` contracts. It has a 1:1 relationship with the quote token (eg. USDC) - ie. one `FXPoolDeployer` contract per quote token.

This PR adds the ability for our UI to track multiple `FXPoolDeployer` contracts through the subgraph, as we gradually add support for more quote tokens.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

We've deployed the changes over to our balancer subgraph polygon clone (trimmed down version, starting from block 49368321 ): https://thegraph.com/hosted-service/subgraph/xave-finance/balancer-v2-polygon

Simply run the "Query FXPools" from the query dropdown and it should return:

- [SBC / USDC.e](https://polygonscan.com/address/0xa5b235fb345b5744cc285045c8118a92f4aef58b): created with the previous/existing `FXPoolDeployer` contract  that has **USDC.e** as quote token ([tx](https://polygonscan.com/tx/0xc000c84860bcb32d8706c4447a61ae8245b707c93c2a68fe885ea745d46c8a11))
- [XSGD / USDC](https://polygonscan.com/address/0xd2ea83f95e3e3aa0d7ef1bd08f7267eddb49728d) : created with a new `FXPoolDeployer` contract that has **USDC** native as quote token ([tx](https://polygonscan.com/tx/0x1122fb4d612f1507fddb7e5f85a641a65db09b9187363f8f2245daf923c55339))

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas

### `dev` -> `master`
- [ ] I have [checked](https://balancer.github.io/balancer-subgraph-v2/status.html) that all beta deployments have synced
- [ ] I have [checked](https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-polygon-prune-v2-beta/graphql?query=%0A%7B%0A++balancers%28block%3A%7Bnumber%3A1%7D%29%7B%0A++++id%0A++%7D%0A%7D) that the earliest block in the polygon pruned deployment is [block, date/time](https://polygonscan.com/block/block)
  - [ ] The earliest block is more than 24 hours old
- [ ] I have checked that core metrics are the same in the beta and production deployments

### Merges to `dev`
- [ ] I have checked that the graft base is not a pruned deployment
