### PR TITLE
Fxpool fix oracle conversion for TXAU and TXAG

### DIFF
--- a/abis/AggregatorConverter.json
+++ b/abis/AggregatorConverter.json
@@ -1,0 +1,259 @@
+[
+  {
+    "type": "constructor",
+    "inputs": [
+      {
+        "name": "_aggregator",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "_divisor",
+        "type": "int256",
+        "internalType": "int256"
+      },
+      {
+        "name": "_description",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "fallback",
+    "stateMutability": "payable"
+  },
+  {
+    "type": "receive",
+    "stateMutability": "payable"
+  },
+  {
+    "type": "function",
+    "name": "AGGR_ADDR",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "DECIMALS",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "DIVISOR",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "int256",
+        "internalType": "int256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "description",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getAnswer",
+    "inputs": [
+      {
+        "name": "roundId",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "int256",
+        "internalType": "int256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getRoundData",
+    "inputs": [
+      {
+        "name": "_roundId",
+        "type": "uint80",
+        "internalType": "uint80"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "roundId",
+        "type": "uint80",
+        "internalType": "uint80"
+      },
+      {
+        "name": "answer",
+        "type": "int256",
+        "internalType": "int256"
+      },
+      {
+        "name": "startedAt",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "updatedAt",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "answeredInRound",
+        "type": "uint80",
+        "internalType": "uint80"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "latestAnswer",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "int256",
+        "internalType": "int256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "latestRoundData",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "roundId",
+        "type": "uint80",
+        "internalType": "uint80"
+      },
+      {
+        "name": "answer",
+        "type": "int256",
+        "internalType": "int256"
+      },
+      {
+        "name": "startedAt",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "updatedAt",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "answeredInRound",
+        "type": "uint80",
+        "internalType": "uint80"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "proposedGetRoundData",
+    "inputs": [
+      {
+        "name": "roundId",
+        "type": "uint80",
+        "internalType": "uint80"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "id",
+        "type": "uint80",
+        "internalType": "uint80"
+      },
+      {
+        "name": "answer",
+        "type": "int256",
+        "internalType": "int256"
+      },
+      {
+        "name": "startedAt",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "updatedAt",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "answeredInRound",
+        "type": "uint80",
+        "internalType": "uint80"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "proposedLatestRoundData",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "id",
+        "type": "uint80",
+        "internalType": "uint80"
+      },
+      {
+        "name": "answer",
+        "type": "int256",
+        "internalType": "int256"
+      },
+      {
+        "name": "startedAt",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "updatedAt",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "answeredInRound",
+        "type": "uint80",
+        "internalType": "uint80"
+      }
+    ],
+    "stateMutability": "view"
+  }
+]

--- a/abis/OunceToGramOracle.json
+++ b/abis/OunceToGramOracle.json
@@ -1,0 +1,236 @@
+[
+  {
+    "type": "constructor",
+    "inputs": [
+      {
+        "name": "_aggregator",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "fallback",
+    "stateMutability": "payable"
+  },
+  {
+    "type": "receive",
+    "stateMutability": "payable"
+  },
+  {
+    "type": "function",
+    "name": "AGGR_ADDR",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "GRAM_PER_TROYOUNCE",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "int256",
+        "internalType": "int256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "aggregator",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getAnswer",
+    "inputs": [
+      {
+        "name": "roundId",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "int256",
+        "internalType": "int256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getRoundData",
+    "inputs": [
+      {
+        "name": "_roundId",
+        "type": "uint80",
+        "internalType": "uint80"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "roundId",
+        "type": "uint80",
+        "internalType": "uint80"
+      },
+      {
+        "name": "answer",
+        "type": "int256",
+        "internalType": "int256"
+      },
+      {
+        "name": "startedAt",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "updatedAt",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "answeredInRound",
+        "type": "uint80",
+        "internalType": "uint80"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "latestAnswer",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "int256",
+        "internalType": "int256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "latestRoundData",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "roundId",
+        "type": "uint80",
+        "internalType": "uint80"
+      },
+      {
+        "name": "answer",
+        "type": "int256",
+        "internalType": "int256"
+      },
+      {
+        "name": "startedAt",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "updatedAt",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "answeredInRound",
+        "type": "uint80",
+        "internalType": "uint80"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "proposedGetRoundData",
+    "inputs": [
+      {
+        "name": "roundId",
+        "type": "uint80",
+        "internalType": "uint80"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "id",
+        "type": "uint80",
+        "internalType": "uint80"
+      },
+      {
+        "name": "answer",
+        "type": "int256",
+        "internalType": "int256"
+      },
+      {
+        "name": "startedAt",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "updatedAt",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "answeredInRound",
+        "type": "uint80",
+        "internalType": "uint80"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "proposedLatestRoundData",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "id",
+        "type": "uint80",
+        "internalType": "uint80"
+      },
+      {
+        "name": "answer",
+        "type": "int256",
+        "internalType": "int256"
+      },
+      {
+        "name": "startedAt",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "updatedAt",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "answeredInRound",
+        "type": "uint80",
+        "internalType": "uint80"
+      }
+    ],
+    "stateMutability": "view"
+  }
+]

--- a/manifest.template.yaml
+++ b/manifest.template.yaml
@@ -2425,6 +2425,10 @@ templates:
           file: ./abis/Assimilator.json
         - name: ChainlinkPriceFeed
           file: ./abis/ChainlinkPriceFeed.json
+        - name: AggregatorConverter
+          file: ./abis/AggregatorConverter.json
+        - name: OunceToGramOracle
+          file: ./abis/OunceToGramOracle.json
       eventHandlers:
         - event: NewFXPool(indexed address,indexed bytes32,indexed address)
           handler: handleNewFXPoolV2

--- a/schema.graphql
+++ b/schema.graphql
@@ -406,6 +406,6 @@ type ProtocolIdData @entity {
 type FXOracle @entity {
   id: ID! # FX oracle aggregator address
   tokens: [Bytes!]! # token addresses using this oracle
-  divisor: String! # some oracles require conversion
-  decimals: Int!
+  divisor: String # some oracles require conversion
+  decimals: Int
 }

--- a/schema.graphql
+++ b/schema.graphql
@@ -402,7 +402,10 @@ type ProtocolIdData @entity {
   name: String!
 }
 
+# FXOracle entity where the id is the Chainlink aggregator address
 type FXOracle @entity {
   id: ID! # FX oracle aggregator address
   tokens: [Bytes!]! # token addresses using this oracle
+  divisor: String! # some oracles require conversion
+  decimals: Int!
 }

--- a/src/mappings/poolFactory.ts
+++ b/src/mappings/poolFactory.ts
@@ -697,11 +697,6 @@ function handleNewFXPool(event: ethereum.Event, permissionless: boolean): void {
   // Create templates for each token Offchain Aggregator
   let tokensAddresses: Address[] = changetype<Address[]>(tokens);
 
-  log.info('handleNewFXPool NEW POOL poolAddress {}; permissionless {};', [
-    poolAddress.toHexString(),
-    permissionless.toString(),
-  ]);
-
   if (!permissionless) {
     // For FXPoolFactory, use hardcoded aggregator addresses
     tokensAddresses.forEach((tokenAddress) => {

--- a/src/mappings/pricing.ts
+++ b/src/mappings/pricing.ts
@@ -26,7 +26,6 @@ import {
   MAX_TIME_DIFF_FOR_PRICING,
 } from './helpers/constants';
 import { AnswerUpdated } from '../types/templates/OffchainAggregator/AccessControlledOffchainAggregator';
-import { getFXOracle } from './helpers/misc';
 export function isPricingAsset(asset: Address): boolean {
   for (let i: i32 = 0; i < PRICING_ASSETS.length; i++) {
     if (PRICING_ASSETS[i] == asset) return true;
@@ -372,7 +371,7 @@ export function setWrappedTokenPrice(pool: Pool, poolId: string, block_number: B
 
 export function handleAnswerUpdated(event: AnswerUpdated): void {
   const aggregatorAddress = event.address;
-  let answer = event.params.current;
+  const answer = event.params.current;
   const tokenAddressesToUpdate: Address[] = [];
 
   // Check if the aggregator is under FX_ASSET_AGGREGATORS first (FXPoolFactory version)
@@ -388,9 +387,6 @@ export function handleAnswerUpdated(event: AnswerUpdated): void {
     for (let i = 0; i < oracle.tokens.length; i++) {
       const tokenAddress = Address.fromBytes(oracle.tokens[i]);
       const tokenExists = tokenAddressesToUpdate.includes(tokenAddress);
-        oracle.tokens[i].toHexString(),
-        tokenExists.toString(),
-      ]);
       if (!tokenExists) {
         tokenAddressesToUpdate.push(tokenAddress);
       }


### PR DESCRIPTION
# Description

This fix is a follow-up of PR [#575 Multiple Quote Tokens support for FXPools: FXPoolDeployerTracker](https://github.com/balancer/balancer-subgraph-v2/pull/575)

For some RWA tokens (metal tokens like Aurus: TXAU, TXAG), the token represents a gram unit while the Chainlink Aggregator returns the price in $ / ounce. For example: each [TXAU](0xA6da8C8999c094432c77E7d318951D34019AF24B) token represents a gram of Gold while the [Chainlink Aggregator for XAU](https://polygonscan.com/address/0x0C466540B2ee1a31b441671eac0ca886e051E410) will return the price in ounces. Because of this we added an oracle adaptor contract in front of said aggregator. We found a workaround so that the subgraph code can dynamically pickup on such oracle adapter contracts. Moving forward we will be using an `AggregatorConverter` that exposes a `DIVISOR` and `DECIMALS` public state variables. With these 2 parameters the subgraph code can perform the required conversion for the `AnswerUpdated` event that is emitted directly by the Chainlink Aggregator.

Additionally, we spotted an older bug in our code whereby if one of the tokens in a pool happened to not have an existing oracle associated with it, the code would `return` thus exiting the loop and missing out on subsequent valid tokens / oracles. The way this is reflected in the subgraph results that the TXAU token would return a `latestFXPrice` of `null`. We only noticed this bug in the fork/testing environment, production doesn't seem to have it (possibly because prod gets re-synced from an earlier block).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

We've deployed the changes over to our balancer subgraph polygon clone (trimmed down version, starting from block 54559454 ): https://thegraph.com/hosted-service/subgraph/xave-finance/balancer-v2-polygon

Simply run the following query:

```
query MyQuery {
  tokens(first: 100, where: {symbol_in: ["TXAU", "TXAG"]}) {
    address
    latestFXPrice
    fxOracleDecimals
    decimals
    name
    symbol
  }
}
```

The return should looks like the one below. Both Aurus tokens show the correct price / gram.
```
{
  "data": {
    "tokens": [
      {
        "address": "0x57fcbd6503c8be3b1abad191bc7799ef414a5b31",
        "latestFXPrice": "0.89880627",
        "fxOracleDecimals": 8,
        "decimals": 18,
        "name": "tSILVER",
        "symbol": "TXAG"
      },
      {
        "address": "0xa6da8c8999c094432c77e7d318951d34019af24b",
        "latestFXPrice": "75.01219284",
        "fxOracleDecimals": 8,
        "decimals": 18,
        "name": "tGOLD",
        "symbol": "TXAU"
      }
    ]
  }
}
```

The current production code on polygon returns the price in $ / ounce which is incorrect:

```
{
  "data": {
    "tokens": [
      {
        "address": "0x57fcbd6503c8be3b1abad191bc7799ef414a5b31",
        "latestFXPrice": "27.7",
        "fxOracleDecimals": 8,
        "decimals": 18,
        "name": "tSILVER",
        "symbol": "TXAG"
      },
      {
        "address": "0xa6da8c8999c094432c77e7d318951d34019af24b",
        "latestFXPrice": "2327.83",
        "fxOracleDecimals": 8,
        "decimals": 18,
        "name": "tGOLD",
        "symbol": "TXAU"
      }
    ]
  }
}
```

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas

### `dev` -> `master`
- [ ] I have [checked](https://balancer.github.io/balancer-subgraph-v2/status.html) that all beta deployments have synced
- [ ] I have [checked](https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-polygon-prune-v2-beta/graphql?query=%0A%7B%0A++balancers%28block%3A%7Bnumber%3A1%7D%29%7B%0A++++id%0A++%7D%0A%7D) that the earliest block in the polygon pruned deployment is [block, date/time](https://polygonscan.com/block/block)
  - [ ] The earliest block is more than 24 hours old
- [ ] I have checked that core metrics are the same in the beta and production deployments

### Merges to `dev`
- [ ] I have checked that the graft base is not a pruned deployment
