### PR TITLE
promote dev

### DIFF
--- a/abis/AggregatorConverter.json
+++ b/abis/AggregatorConverter.json
@@ -1,0 +1,259 @@
+[
+  {
+    "type": "constructor",
+    "inputs": [
+      {
+        "name": "_aggregator",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "_divisor",
+        "type": "int256",
+        "internalType": "int256"
+      },
+      {
+        "name": "_description",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "fallback",
+    "stateMutability": "payable"
+  },
+  {
+    "type": "receive",
+    "stateMutability": "payable"
+  },
+  {
+    "type": "function",
+    "name": "AGGR_ADDR",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "DECIMALS",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "DIVISOR",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "int256",
+        "internalType": "int256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "description",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getAnswer",
+    "inputs": [
+      {
+        "name": "roundId",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "int256",
+        "internalType": "int256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getRoundData",
+    "inputs": [
+      {
+        "name": "_roundId",
+        "type": "uint80",
+        "internalType": "uint80"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "roundId",
+        "type": "uint80",
+        "internalType": "uint80"
+      },
+      {
+        "name": "answer",
+        "type": "int256",
+        "internalType": "int256"
+      },
+      {
+        "name": "startedAt",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "updatedAt",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "answeredInRound",
+        "type": "uint80",
+        "internalType": "uint80"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "latestAnswer",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "int256",
+        "internalType": "int256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "latestRoundData",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "roundId",
+        "type": "uint80",
+        "internalType": "uint80"
+      },
+      {
+        "name": "answer",
+        "type": "int256",
+        "internalType": "int256"
+      },
+      {
+        "name": "startedAt",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "updatedAt",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "answeredInRound",
+        "type": "uint80",
+        "internalType": "uint80"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "proposedGetRoundData",
+    "inputs": [
+      {
+        "name": "roundId",
+        "type": "uint80",
+        "internalType": "uint80"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "id",
+        "type": "uint80",
+        "internalType": "uint80"
+      },
+      {
+        "name": "answer",
+        "type": "int256",
+        "internalType": "int256"
+      },
+      {
+        "name": "startedAt",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "updatedAt",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "answeredInRound",
+        "type": "uint80",
+        "internalType": "uint80"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "proposedLatestRoundData",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "id",
+        "type": "uint80",
+        "internalType": "uint80"
+      },
+      {
+        "name": "answer",
+        "type": "int256",
+        "internalType": "int256"
+      },
+      {
+        "name": "startedAt",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "updatedAt",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "answeredInRound",
+        "type": "uint80",
+        "internalType": "uint80"
+      }
+    ],
+    "stateMutability": "view"
+  }
+]

--- a/abis/OunceToGramOracle.json
+++ b/abis/OunceToGramOracle.json
@@ -1,0 +1,236 @@
+[
+  {
+    "type": "constructor",
+    "inputs": [
+      {
+        "name": "_aggregator",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "fallback",
+    "stateMutability": "payable"
+  },
+  {
+    "type": "receive",
+    "stateMutability": "payable"
+  },
+  {
+    "type": "function",
+    "name": "AGGR_ADDR",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "GRAM_PER_TROYOUNCE",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "int256",
+        "internalType": "int256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "aggregator",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getAnswer",
+    "inputs": [
+      {
+        "name": "roundId",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "int256",
+        "internalType": "int256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getRoundData",
+    "inputs": [
+      {
+        "name": "_roundId",
+        "type": "uint80",
+        "internalType": "uint80"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "roundId",
+        "type": "uint80",
+        "internalType": "uint80"
+      },
+      {
+        "name": "answer",
+        "type": "int256",
+        "internalType": "int256"
+      },
+      {
+        "name": "startedAt",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "updatedAt",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "answeredInRound",
+        "type": "uint80",
+        "internalType": "uint80"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "latestAnswer",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "int256",
+        "internalType": "int256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "latestRoundData",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "roundId",
+        "type": "uint80",
+        "internalType": "uint80"
+      },
+      {
+        "name": "answer",
+        "type": "int256",
+        "internalType": "int256"
+      },
+      {
+        "name": "startedAt",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "updatedAt",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "answeredInRound",
+        "type": "uint80",
+        "internalType": "uint80"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "proposedGetRoundData",
+    "inputs": [
+      {
+        "name": "roundId",
+        "type": "uint80",
+        "internalType": "uint80"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "id",
+        "type": "uint80",
+        "internalType": "uint80"
+      },
+      {
+        "name": "answer",
+        "type": "int256",
+        "internalType": "int256"
+      },
+      {
+        "name": "startedAt",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "updatedAt",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "answeredInRound",
+        "type": "uint80",
+        "internalType": "uint80"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "proposedLatestRoundData",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "id",
+        "type": "uint80",
+        "internalType": "uint80"
+      },
+      {
+        "name": "answer",
+        "type": "int256",
+        "internalType": "int256"
+      },
+      {
+        "name": "startedAt",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "updatedAt",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "answeredInRound",
+        "type": "uint80",
+        "internalType": "uint80"
+      }
+    ],
+    "stateMutability": "view"
+  }
+]

--- a/manifest.template.yaml
+++ b/manifest.template.yaml
@@ -2425,6 +2425,10 @@ templates:
           file: ./abis/Assimilator.json
         - name: ChainlinkPriceFeed
           file: ./abis/ChainlinkPriceFeed.json
+        - name: AggregatorConverter
+          file: ./abis/AggregatorConverter.json
+        - name: OunceToGramOracle
+          file: ./abis/OunceToGramOracle.json
       eventHandlers:
         - event: NewFXPool(indexed address,indexed bytes32,indexed address)
           handler: handleNewFXPoolV2

--- a/manifest.template.yaml
+++ b/manifest.template.yaml
@@ -1763,6 +1763,10 @@ dataSources:
           file: ./abis/Assimilator.json
         - name: ChainlinkPriceFeed
           file: ./abis/ChainlinkPriceFeed.json
+        - name: AggregatorConverter
+          file: ./abis/AggregatorConverter.json
+        - name: OunceToGramOracle
+          file: ./abis/OunceToGramOracle.json
       eventHandlers:
         - event: NewFXPool(indexed address,indexed bytes32,indexed address)
           handler: handleNewFXPoolV2

--- a/networks.yaml
+++ b/networks.yaml
@@ -484,7 +484,7 @@ arbitrum:
     address: "0x0bd5EC16658346eeCd5dE8c704a38Efe02B5DA69"
     startBlock: 183603903
   Gyro2V2PoolFactory:
-    address: "0x8342b910815b0127c98e7717d4276c1d393478b6"
+    address: "0x7a36527A02d96693b0AF2b70421F952816a4a088"
     startBlock: 194366254
 bnb:
   network: bsc

--- a/networks.yaml
+++ b/networks.yaml
@@ -483,6 +483,9 @@ arbitrum:
   FXPoolDeployer:
     address: "0x0bd5EC16658346eeCd5dE8c704a38Efe02B5DA69"
     startBlock: 183603903
+  Gyro2V2PoolFactory:
+    address: "0x8342b910815b0127c98e7717d4276c1d393478b6"
+    startBlock: 194366254
 bnb:
   network: bsc
   Vault:

--- a/networks.yaml
+++ b/networks.yaml
@@ -838,6 +838,9 @@ base:
   TempLiquidityBootstrappingPoolFactory:
     address: "0x0c6052254551EAe3ECac77B01DFcf1025418828f"
     startBlock: 1206531
+  GyroEV2PoolFactory:
+    address: "0x15e86Be6084C6A5a8c17732D398dFbC2Ec574CEC"
+    startBlock: 13035219
 fantom:
   network: fantom
   # graft:

--- a/networks.yaml
+++ b/networks.yaml
@@ -1,11 +1,11 @@
 mainnet:
   network: mainnet
   graft:
-    # rETH/weETH pool creation to fix USD metrics
-    block: 18774976
+    # Apr-11-2024 02:34:11 PM +UTC
+    block: 19633000
     # always make sure the base subgraph has not been pruned
     # it should be possible to run time travel queries on it going back to the vault's startBlock
-    base: QmYacPMeFA5359vDGknEc8aPAieiXHUa8ksfJ6H7FnzRrB
+    base: QmX6XKG5dSUf2FjKpeAdVPjbZSZ5qptnGGegHcwk4367Ph
   EventEmitter:
     address: "0x1ACfEEA57d2ac674d7E65964f155AB9348A6C290"
     startBlock: 16419620
@@ -244,12 +244,12 @@ polygon:
     block: 54559455
     # this will be the base of the unpruned deployment, so make sure it has not been pruned
     # it should be possible to run time travel queries on it going back to the vault's startBlock
-    base: QmfFmtcLKRugnPe8HFmmvdtUgM6gvUSSsFXGeCTX6sH4Zg
+    base: Qmd6J5P1KYqwUmFupQ98Le7tGstDv3uUhHAwAzyPiicixw
   graft_pruned:
     # FXPoolDeployerTracker start block
     block: 54559455
     # this will be the base of the pruned deployment, so it is ok if it is a pruned subgraph
-    base: QmfFmtcLKRugnPe8HFmmvdtUgM6gvUSSsFXGeCTX6sH4Zg
+    base: Qmd6J5P1KYqwUmFupQ98Le7tGstDv3uUhHAwAzyPiicixw
   EventEmitter:
     address: "0xcdcECFa416EE3022030E707dC3EA13a8997D74c8"
     startBlock: 38152461
@@ -380,7 +380,7 @@ arbitrum:
     block: 191573392
     # always make sure the base subgraph has not been pruned
     # it should be possible to run time travel queries on it going back to the vault's startBlock
-    base: QmZewqKt12daEoy7P9SjDfsGheVq8VqPj1ytVr9usKaBtq
+    base: Qmdwyva2Qn28ZA1NDffAajmWKG8MgruNFZH5BKs2ZWMX4b
   EventEmitter:
     address: "0x8f32D631093B5418d0546f77442c5fa66187E59D"
     startBlock: 53475240
@@ -583,11 +583,11 @@ gnosis:
 optimism:
   network: optimism
   graft:
-    # Mar-18-2024 09:52:57 PM +UTC
-    block: 117600000
+    # Apr-11-2024 03:19:37 PM +UTC
+    block: 118625000
     # always make sure the base subgraph has not been pruned
     # it should be possible to run time travel queries on it going back to the vault's startBlock
-    base: QmYF2scyywkphqPgue1M4Q6kgwsMtETnhmJXq44SCguqe3
+    base: QmdDQKt3Q8AaWHmTKGLFXxsgrEikNSofqMu7LqYtTGntKh
   EventEmitter:
     address: "0x082990116f256E078572a1b69772115d2cF6b0a2"
     startBlock: 99124541

--- a/schema.graphql
+++ b/schema.graphql
@@ -406,6 +406,6 @@ type ProtocolIdData @entity {
 type FXOracle @entity {
   id: ID! # FX oracle aggregator address
   tokens: [Bytes!]! # token addresses using this oracle
-  divisor: String! # some oracles require conversion
-  decimals: Int!
+  divisor: String # some oracles require conversion
+  decimals: Int
 }

--- a/schema.graphql
+++ b/schema.graphql
@@ -402,7 +402,10 @@ type ProtocolIdData @entity {
   name: String!
 }
 
+# FXOracle entity where the id is the Chainlink aggregator address
 type FXOracle @entity {
   id: ID! # FX oracle aggregator address
   tokens: [Bytes!]! # token addresses using this oracle
+  divisor: String! # some oracles require conversion
+  decimals: Int!
 }

--- a/src/mappings/poolFactory.ts
+++ b/src/mappings/poolFactory.ts
@@ -697,11 +697,6 @@ function handleNewFXPool(event: ethereum.Event, permissionless: boolean): void {
   // Create templates for each token Offchain Aggregator
   let tokensAddresses: Address[] = changetype<Address[]>(tokens);
 
-  log.info('handleNewFXPool NEW POOL poolAddress {}; permissionless {};', [
-    poolAddress.toHexString(),
-    permissionless.toString(),
-  ]);
-
   if (!permissionless) {
     // For FXPoolFactory, use hardcoded aggregator addresses
     tokensAddresses.forEach((tokenAddress) => {

--- a/src/mappings/pricing.ts
+++ b/src/mappings/pricing.ts
@@ -26,7 +26,6 @@ import {
   MAX_TIME_DIFF_FOR_PRICING,
 } from './helpers/constants';
 import { AnswerUpdated } from '../types/templates/OffchainAggregator/AccessControlledOffchainAggregator';
-import { getFXOracle } from './helpers/misc';
 export function isPricingAsset(asset: Address): boolean {
   for (let i: i32 = 0; i < PRICING_ASSETS.length; i++) {
     if (PRICING_ASSETS[i] == asset) return true;
@@ -372,7 +371,7 @@ export function setWrappedTokenPrice(pool: Pool, poolId: string, block_number: B
 
 export function handleAnswerUpdated(event: AnswerUpdated): void {
   const aggregatorAddress = event.address;
-  let answer = event.params.current;
+  const answer = event.params.current;
   const tokenAddressesToUpdate: Address[] = [];
 
   // Check if the aggregator is under FX_ASSET_AGGREGATORS first (FXPoolFactory version)
@@ -388,9 +387,6 @@ export function handleAnswerUpdated(event: AnswerUpdated): void {
     for (let i = 0; i < oracle.tokens.length; i++) {
       const tokenAddress = Address.fromBytes(oracle.tokens[i]);
       const tokenExists = tokenAddressesToUpdate.includes(tokenAddress);
-        oracle.tokens[i].toHexString(),
-        tokenExists.toString(),
-      ]);
       if (!tokenExists) {
         tokenAddressesToUpdate.push(tokenAddress);
       }


### PR DESCRIPTION
# Description

- #582 
- #584 
- #586 
- #587 
- #588 

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

- [x] [GyroEV2 pools on Base](https://api.studio.thegraph.com/query/24660/balancer-base-v2-beta/version/latest/graphql?query=%7B%0A%09pools(%0A++++where:+%7B%0A++++++poolType:+%22GyroE%22%0A++++++poolTypeVersion:+2%0A++++%7D%0A++)+%7B%0A%09++id%0A++++c%0A++++s%0A++++u%0A++++v%0A++++w%0A++++z%0A++++dSq%0A++++tauAlphaX%0A++++tauAlphaY%0A++++tauBetaX%0A++++tauBetaY%0A++++alpha%0A++++beta%0A++++lambda%0A%09%7D%0A%7D)
- [x] [Gyro2V2 pools on Arbitrum](https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-arbitrum-v2-beta/graphql?query=%7B%0A%09pools(%0A++++where:+%7B%0A++++++poolType:+%22Gyro2%22%0A++++++poolTypeVersion:+2%0A++++%7D%0A++)+%7B%0A%09++id%0A++++sqrtAlpha%0A++++sqrtBeta%0A%09%7D%0A%7D)
- [x] [TXAG and TXAU pools reporting correct TVL](https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-polygon-v2-beta/graphql?query=%7B%0A%09pools(%0A++++where:+%7B%0A++++++id_in:+%5B%0A++++++++%220x98f9220f128eed5e853cd3d23a2c33e1f98f8311000200000000000000000e55%22,%0A++++++++%220x31ac27805b0665695071b640bf2abfbe0736c02e000200000000000000000e56%22%0A++++++%5D%0A++++%7D%0A++)+%7B%0A%09++id%0A++++totalLiquidity%0A++++tokens+%7B%0A++++++symbol%0A++++++balance%0A++++++token+%7B%0A++++++++latestFXPrice%0A++++++%7D%0A++++%7D%0A%09%7D%0A%7D%0A)

### `dev` -> `master`
- [x] I have [checked](https://balancer.github.io/balancer-subgraph-v2/status.html) that all beta deployments have synced
- [x] I have [checked](https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-polygon-prune-v2-beta/graphql?query=%0A%7B%0A++balancers%28block%3A%7Bnumber%3A1%7D%29%7B%0A++++id%0A++%7D%0A%7D) that the earliest block in the polygon pruned deployment is [55739295, Apr-12-2024 01:42:15 PM](https://polygonscan.com/block/55739295)
  - [x] The earliest block is more than 24 hours old
- [x] I have checked that core metrics are the same in the beta and production deployments
