### PR TITLE
fix negative total shares and holders count

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Install node
         uses: actions/setup-node@v1
         with:
-          node-version: 16
+          node-version: 18
       - name: Install
         run: yarn --frozen-lockfile
       - name: Codegen
@@ -28,7 +28,7 @@ jobs:
       - name: Install node
         uses: actions/setup-node@v1
         with:
-          node-version: 16
+          node-version: 18
       - name: Install
         run: yarn --frozen-lockfile
       - name: Lint

--- a/src/mappings/poolController.ts
+++ b/src/mappings/poolController.ts
@@ -56,7 +56,7 @@ import {
   hexToBigInt,
   getBalancerSnapshot,
 } from './helpers/misc';
-import { ONE_BD, ProtocolFeeType, ZERO_ADDRESS, ZERO_BD } from './helpers/constants';
+import { ONE_BD, ProtocolFeeType, VAULT_ADDRESS, ZERO_ADDRESS, ZERO_BD } from './helpers/constants';
 import { updateAmpFactor } from './helpers/stable';
 import { getPoolTokenManager, getPoolTokens } from './helpers/pools';
 import {
@@ -678,11 +678,21 @@ export function handleTransfer(event: Transfer): void {
     poolShareFrom.save();
   }
 
-  if (poolShareTo !== null && poolShareTo.balance.notEqual(ZERO_BD) && poolShareToBalance.equals(ZERO_BD)) {
+  if (
+    poolShareTo !== null &&
+    poolShareTo.balance.notEqual(ZERO_BD) &&
+    poolShareToBalance.equals(ZERO_BD) &&
+    poolShareTo.userAddress != VAULT_ADDRESS.toHex()
+  ) {
     pool.holdersCount = pool.holdersCount.plus(BigInt.fromI32(1));
   }
 
-  if (poolShareFrom !== null && poolShareFrom.balance.equals(ZERO_BD) && poolShareFromBalance.notEqual(ZERO_BD)) {
+  if (
+    poolShareFrom !== null &&
+    poolShareFrom.balance.equals(ZERO_BD) &&
+    poolShareFromBalance.notEqual(ZERO_BD) &&
+    poolShareFrom.userAddress != VAULT_ADDRESS.toHex()
+  ) {
     pool.holdersCount = pool.holdersCount.minus(BigInt.fromI32(1));
   }
 

--- a/src/mappings/poolFactory.ts
+++ b/src/mappings/poolFactory.ts
@@ -22,7 +22,7 @@ import {
 } from './helpers/misc';
 import { updatePoolWeights } from './helpers/weighted';
 
-import { BigInt, Address, Bytes, ethereum, log } from '@graphprotocol/graph-ts';
+import { BigInt, Address, Bytes, ethereum } from '@graphprotocol/graph-ts';
 
 import { PoolCreated } from '../types/WeightedPoolFactory/WeightedPoolFactory';
 import { AaveLinearPoolCreated } from '../types/AaveLinearPoolV3Factory/AaveLinearPoolV3Factory';

--- a/src/mappings/pricing.ts
+++ b/src/mappings/pricing.ts
@@ -420,6 +420,7 @@ export function handleAnswerUpdated(event: AnswerUpdated): void {
     } else if (oracle && oracle.divisor !== null && oracle.decimals) {
       const updatedAnswer = answer
         .times(BigInt.fromString('10').pow(oracle.decimals as u8))
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         .div(BigInt.fromString(oracle.divisor!));
       token.latestFXPrice = scaleDown(updatedAnswer, 8);
     } else {

--- a/src/mappings/vault.ts
+++ b/src/mappings/vault.ts
@@ -31,7 +31,6 @@ import {
   getTradePairSnapshot,
   getTradePair,
   getBalancerSnapshot,
-  bytesToAddress,
   getPoolShare,
 } from './helpers/misc';
 import { updatePoolWeights } from './helpers/weighted';

--- a/src/mappings/vault.ts
+++ b/src/mappings/vault.ts
@@ -273,24 +273,11 @@ function handlePoolJoined(event: PoolBalanceChanged): void {
     pool.save();
 
     // This amount will also be transferred to the vault,
-    // causing the vault's 'user shares' to incorrectly increase,
-    // so we need to negate it. We do so by processing a mock transfer event
-    // from the vault to the zero address
-    const mockEvent = new Transfer(
-      bytesToAddress(pool.address),
-      event.logIndex,
-      event.transactionLogIndex,
-      event.logType,
-      event.block,
-      event.transaction,
-      [
-        new ethereum.EventParam('from', ethereum.Value.fromAddress(VAULT_ADDRESS)),
-        new ethereum.EventParam('to', ethereum.Value.fromAddress(ZERO_ADDRESS)),
-        new ethereum.EventParam('value', ethereum.Value.fromUnsignedBigInt(preMintedBpt)),
-      ],
-      event.receipt
-    );
-    handleTransfer(mockEvent);
+    // causing the vault's 'user shares' to incorrectly
+    // increase, so we need to subtract it.
+    const vaultPoolShare = getPoolShare(poolId, VAULT_ADDRESS);
+    vaultPoolShare.balance = vaultPoolShare.balance.minus(tokenToDecimal(preMintedBpt, 18));
+    vaultPoolShare.save();
   }
 
   updatePoolLiquidity(poolId, event.block.number, event.block.timestamp);


### PR DESCRIPTION
# Description

#591 fixed a scope issue where `Pool` entity was not saved before being passed/instantiated to another functions. OOTH that fix exposed another issue as `handleTransfer()` not only substracts the pre-minted BPT from the Vault (that's just what we need) but also subtracts the value from `pool.totalShares` leading to negative shares. Instead of using the function, I'm simply subtracting the pre-minted BPTs from Vault's pool share directly.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas

### `dev` -> `master`
- [ ] I have [checked](https://balancer.github.io/balancer-subgraph-v2/status.html) that all beta deployments have synced
- [ ] I have [checked](https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-polygon-prune-v2-beta/graphql?query=%0A%7B%0A++balancers%28block%3A%7Bnumber%3A1%7D%29%7B%0A++++id%0A++%7D%0A%7D) that the earliest block in the polygon pruned deployment is [block, date/time](https://polygonscan.com/block/block)
  - [ ] The earliest block is more than 24 hours old
- [ ] I have checked that core metrics are the same in the beta and production deployments

### Merges to `dev`
- [ ] I have checked that the graft base is not a pruned deployment
